### PR TITLE
Paginate datasets and organizations

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,8 +3,8 @@
 # data.gouv.fr API base URL
 datagouvfr_api_url: https://www.data.gouv.fr/api
 
-frontend_setttings:
-  organizations_list_page_size: 8
+# display settings
+organizations_list_page_size: 8
 
 # list of organisations' ids that should be handled by the portal
 # to find an id go to https://www.data.gouv.fr/fr/organizations/ministere-de-la-transition-ecologique/

--- a/config.yaml
+++ b/config.yaml
@@ -3,6 +3,9 @@
 # data.gouv.fr API base URL
 datagouvfr_api_url: https://www.data.gouv.fr/api
 
+frontend_setttings:
+  organizations_list_page_size: 8
+
 # list of organisations' ids that should be handled by the portal
 # to find an id go to https://www.data.gouv.fr/fr/organizations/ministere-de-la-transition-ecologique/
 # then Informations > ID at the bottom of the page

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.4.0",
         "pinia": "^2.1.4",
         "vue": "^3.3.4",
+        "vue-loading-overlay": "^6.0.3",
         "vue-router": "^4.2.2",
         "vue3-text-clamp": "^0.1.1",
         "vue3-toastify": "^0.1.11"
@@ -2469,6 +2470,17 @@
       },
       "peerDependencies": {
         "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/vue-loading-overlay": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vue-loading-overlay/-/vue-loading-overlay-6.0.3.tgz",
+      "integrity": "sha512-Ab0hqnVKasVS2mNUo8Wkm95mSbk5fXp/karZmMou5yP0hTUOox/kZuBLNwgzJ4kFP829wFJl7O7FN1Dr0kRaVQ==",
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
       }
     },
     "node_modules/vue-router": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "pinia": "^2.1.4",
         "vue": "^3.3.4",
         "vue-router": "^4.2.2",
+        "vue3-text-clamp": "^0.1.1",
         "vue3-toastify": "^0.1.11"
       },
       "devDependencies": {
@@ -23,6 +24,7 @@
         "eslint": "^8.39.0",
         "eslint-plugin-vue": "^9.11.0",
         "prettier": "^2.8.8",
+        "sass": "^1.63.6",
         "vite": "^4.3.9"
       }
     },
@@ -793,6 +795,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -820,6 +835,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -834,6 +858,18 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/callsites": {
@@ -859,6 +895,45 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/color-convert": {
@@ -1281,6 +1356,18 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -1456,6 +1543,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immutable": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
+      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
+      "dev": true
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -1497,6 +1590,18 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1516,6 +1621,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-path-inside": {
@@ -1679,6 +1793,15 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -2006,6 +2129,23 @@
         }
       ]
     },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resize-detector": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/resize-detector/-/resize-detector-0.3.0.tgz",
+      "integrity": "sha512-R/tCuvuOHQ8o2boRP6vgx8hXCCy87H1eY9V5imBYeVNyNVpuL9ciReSccLj2gDcax9+2weXy3bc8Vv+NRXeEvQ=="
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2079,10 +2219,27 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/sass": {
+      "version": "1.63.6",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.63.6.tgz",
+      "integrity": "sha512-MJuxGMHzaOW7ipp+1KdELtqKbfAWbH7OLIdoSMnVe3EXPMTmxTmlaZDCTsgIpPCs3w99lLo9/zDKkOrJuT5byw==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -2169,6 +2326,18 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
     },
     "node_modules/tosource": {
       "version": "2.0.0-alpha.3",
@@ -2314,6 +2483,19 @@
       },
       "peerDependencies": {
         "vue": "^3.2.0"
+      }
+    },
+    "node_modules/vue3-text-clamp": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/vue3-text-clamp/-/vue3-text-clamp-0.1.1.tgz",
+      "integrity": "sha512-l/30RvXLkw50axAjswAK1DmvbUc5Oyhq9GkvD98p8pykrLkIajRi3evVsMnahMBK0O7+EGIK9RbIOKPyRfuw7w==",
+      "dependencies": {
+        "resize-detector": "^0.3.0",
+        "vue": "^3.2.37"
+      },
+      "peerDependencies": {
+        "resize-detector": "^0.3.0",
+        "vue": "^3.2.37"
       }
     },
     "node_modules/vue3-toastify": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "axios": "^1.4.0",
     "pinia": "^2.1.4",
     "vue": "^3.3.4",
+    "vue-loading-overlay": "^6.0.3",
     "vue-router": "^4.2.2",
     "vue3-text-clamp": "^0.1.1",
     "vue3-toastify": "^0.1.11"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "pinia": "^2.1.4",
     "vue": "^3.3.4",
     "vue-router": "^4.2.2",
+    "vue3-text-clamp": "^0.1.1",
     "vue3-toastify": "^0.1.11"
   },
   "devDependencies": {
@@ -25,6 +26,7 @@
     "eslint": "^8.39.0",
     "eslint-plugin-vue": "^9.11.0",
     "prettier": "^2.8.8",
+    "sass": "^1.63.6",
     "vite": "^4.3.9"
   }
 }

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -1,0 +1,38 @@
+<script setup>
+defineProps(["title", "description", "img", "link", "altImg"])
+</script>
+
+<template>
+  <div class="fr-card fr-enlarge-link">
+    <div class="fr-card__body">
+      <div class="fr-card__content">
+        <h3 class="fr-card__title">
+          <router-link :to="link">{{ title }}</router-link>
+        </h3>
+        <p class="fr-card__desc">
+          <text-clamp v-if="description" :auto-resize="true" :text="description" :max-lines="2" />
+        </p>
+      </div>
+    </div>
+    <div class="fr-card__header">
+      <div class="fr-card__img">
+        <img
+          v-if="img"
+          class="fr-responsive-img"
+          :src="img"
+          :alt="altImg"
+        >
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.fr-card {
+  &__img {
+    img {
+      object-fit: contain;
+    }
+  }
+}
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ import { createPinia } from "pinia"
 import VueDsfr from "@gouvminint/vue-dsfr"   // Import (par défaut) de la bibliothèque
 import App from "./App.vue"
 import router from "./router"
+import TextClamp from 'vue3-text-clamp'
 
 const app = createApp(App)
 const pinia = createPinia()
@@ -15,5 +16,6 @@ const pinia = createPinia()
 app.use(router)
 app.use(VueDsfr)
 app.use(pinia)
+app.use(TextClamp)
 
 app.mount("#app")

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 import "@gouvfr/dsfr/dist/dsfr.min.css"      // Import des styles du DSFR
 import "@gouvminint/vue-dsfr/styles"         // Import des styles globaux propre à VueDSFR
 import "vue3-toastify/dist/index.css"
+import "vue-loading-overlay/dist/css/index.css"
 import "./assets/main.css"
 
 import { createApp } from "vue"
@@ -8,7 +9,9 @@ import { createPinia } from "pinia"
 import VueDsfr from "@gouvminint/vue-dsfr"   // Import (par défaut) de la bibliothèque
 import App from "./App.vue"
 import router from "./router"
+
 import TextClamp from 'vue3-text-clamp'
+import { LoadingPlugin } from 'vue-loading-overlay'
 
 const app = createApp(App)
 const pinia = createPinia()
@@ -16,6 +19,8 @@ const pinia = createPinia()
 app.use(router)
 app.use(VueDsfr)
 app.use(pinia)
+
 app.use(TextClamp)
+app.use(LoadingPlugin)
 
 app.mount("#app")

--- a/src/services/api/DatagouvfrAPI.js
+++ b/src/services/api/DatagouvfrAPI.js
@@ -2,6 +2,9 @@ import config from "@/config"
 import { watch } from "vue"
 import { useFetch } from "../../composables/fetch"
 import { toast } from "vue3-toastify"
+import { useLoading } from 'vue-loading-overlay'
+
+const $loading = useLoading()
 
 /**
  * A composable wrapper around data.gouv.fr's API
@@ -27,7 +30,8 @@ export default class DatagouvfrAPI {
    * @returns {import("../../composables/fetch").ComposableFetchResult}
    */
   makeRequestAndHandleResponse (url) {
-    const { data, error } = useFetch(url)
+    const loader = $loading.show()
+    const { data, error } = useFetch(url, () => loader.hide())
     // TODO: unwatch when request is done?
     watch(error, (errorValue) => {
       if (errorValue && errorValue.message) {

--- a/src/services/api/resources/OrganizationsAPI.js
+++ b/src/services/api/resources/OrganizationsAPI.js
@@ -9,8 +9,8 @@ export default class OrganizationsAPI extends DatagouvfrAPI {
    * @param {str} org_id
    * @returns {import("../../../composables/fetch").ComposableFetchResult}
    */
-  getDatasets (org_id) {
-    const url = `${this.url()}/${org_id}/datasets/`
+  getDatasets (org_id, page = 1) {
+    const url = `${this.url()}/${org_id}/datasets/?page=${page}`
     return this.makeRequestAndHandleResponse(url)
   }
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -81,15 +81,45 @@ export const useOrganizationStore = defineStore("organization", {
   }),
   actions: {
     /**
-     * Init the organization store from the config file values
+     * Get an organizations pagination object from config infos
      *
      * @returns {Array<object>}
      */
-    fillFromConfig () {
-      config.organizations.forEach((org_id) => {
+    getPagination () {
+      const pageSize = config.frontend_setttings.organizations_list_page_size
+      const total = config.organizations.length
+      const nbPages = Math.ceil(total / pageSize)
+      return [...Array(nbPages).keys()].map(page => {
+        page += 1
+        return {
+          label: page,
+          href: "#",
+          title: `Page ${page}`,
+        }
+      })
+    },
+    /**
+     * Get orgs list for a given page from store
+     *
+     * @param {number} page
+     * @returns
+     */
+    getForPage (page = 1) {
+      const pageSize = config.frontend_setttings.organizations_list_page_size
+      return this.data.slice(pageSize * (page - 1), pageSize * page)
+    },
+    /**
+     * Get from store or fetch from API orgs list for a page, using the config
+     *
+     * @param {number} page
+     * @returns {Array<object>}
+     */
+    getOrAddListFromConfig (page = 1) {
+      const pageSize = config.frontend_setttings.organizations_list_page_size
+      config.organizations.slice(pageSize * (page - 1), pageSize * page).forEach((org_id) => {
         this.getOrAdd(org_id)
       })
-      return this.data
+      return this.getForPage(page)
     },
     /**
      * Add an organization to the store
@@ -113,15 +143,5 @@ export const useOrganizationStore = defineStore("organization", {
       const { data } = api.get(org_id)
       return this.add(data)
     },
-    /**
-     * Get datasets for an org from the store or from the API ()
-     *
-     * @param {str} org_id
-     * @returns {object}
-     */
-    getOrAddDatasetForOrg (org_id) {
-      const dStore = useDatasetStore()
-      return dStore.getOrAddDatasetsForOrg(org_id)
-    }
   }
 })

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -86,7 +86,7 @@ export const useOrganizationStore = defineStore("organization", {
      * @returns {Array<object>}
      */
     getPagination () {
-      const pageSize = config.frontend_setttings.organizations_list_page_size
+      const pageSize = config.organizations_list_page_size
       const total = config.organizations.length
       const nbPages = Math.ceil(total / pageSize)
       return [...Array(nbPages).keys()].map(page => {
@@ -102,10 +102,10 @@ export const useOrganizationStore = defineStore("organization", {
      * Get orgs list for a given page from store
      *
      * @param {number} page
-     * @returns
+     * @returns {Array<object>}
      */
     getForPage (page = 1) {
-      const pageSize = config.frontend_setttings.organizations_list_page_size
+      const pageSize = config.organizations_list_page_size
       return this.data.slice(pageSize * (page - 1), pageSize * page)
     },
     /**
@@ -115,7 +115,7 @@ export const useOrganizationStore = defineStore("organization", {
      * @returns {Array<object>}
      */
     getOrAddListFromConfig (page = 1) {
-      const pageSize = config.frontend_setttings.organizations_list_page_size
+      const pageSize = config.organizations_list_page_size
       config.organizations.slice(pageSize * (page - 1), pageSize * page).forEach((org_id) => {
         this.getOrAdd(org_id)
       })

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -9,32 +9,67 @@ const api = new OrganizationsAPI()
 
 export const useDatasetStore = defineStore("dataset", {
   state: () => ({
-    data: []
+    data: {}
   }),
-  getters: {
-    // TODO: maybe move to actions since we have a param
-    datasetsForOrg: (state) => {
-      return (org_id) => {
-        return state.data.filter(d => d.organization.id === org_id || d.organization.slug === org_id)
-      }
-    }
-  },
   actions: {
-    getOrAddDatasetsForOrg (org_id) {
-      const existing = this.datasetsForOrg(org_id)
-      if (existing.length) return existing.value
-      // TODO: handle pagination
-      const { data, error } = api.getDatasets(org_id)
+    /**
+     * Get a datasets pagination object for a given org, from API infos
+     *
+     * @param {str} org_id
+     * @returns {Array<object>}
+     */
+    getDatasetsPaginationForOrg(org_id) {
+      const datasets = this.getDatasetsForOrg(org_id)
+      if (!datasets.data) return []
+      const nbPages = Math.ceil(datasets.total / datasets.page_size)
+      return [...Array(nbPages).keys()].map(page => {
+        page += 1
+        return {
+          label: page,
+          href: "#",
+          title: `Page ${page}`,
+        }
+      })
+    },
+    /**
+     * Get datasets in store for an org and a page
+     *
+     * @param {string} org_id
+     * @param {number} page
+     * @returns {object}
+     */
+    getDatasetsForOrg (org_id, page = 1) {
+      if (!this.data[org_id]) return {}
+      return this.data[org_id].find(d => d.page == page) || {}
+    },
+    /**
+     * Get from store or fetch from API datasets for an org and a page
+     *
+     * @param {string} org_id
+     * @param {number} page
+     * @returns {Array<object>}
+     */
+    getOrAddDatasetsForOrg (org_id, page = 1) {
+      const existing = this.getDatasetsForOrg(org_id, page)
+      if (existing.data) return existing
+      const { data, error } = api.getDatasets(org_id, page)
       // TODO: maybe move to async/await in API to avoid watchers (but will bubble up to component?)
       watch(data, (_data) => {
         if (_data.data) {
-          this.add(_data.data)
+          // store the full results with metadata
+          this.add(org_id, _data)
         }
       })
-      return this.datasetsForOrg(org_id)
+      return this.getDatasetsForOrg(org_id, page)
     },
-    add (datasets) {
-      datasets.forEach(d => this.data.push(d))
+    /**
+     * Store the result of a datasets fetch operation for an org in store
+     *
+     * @param {string} org_id
+     * @param {object} res
+     */
+    add (org_id, res) {
+      this.data[org_id] = [...(this.data[org_id] || []), res]
     },
   }
 })
@@ -45,23 +80,45 @@ export const useOrganizationStore = defineStore("organization", {
     data: []
   }),
   actions: {
-    fillFromConfig (withDatasets = false) {
+    /**
+     * Init the organization store from the config file values
+     *
+     * @returns {Array<object>}
+     */
+    fillFromConfig () {
       config.organizations.forEach((org_id) => {
-        this.getOrAdd(org_id, withDatasets)
+        this.getOrAdd(org_id)
       })
       return this.data
     },
+    /**
+     * Add an organization to the store
+     *
+     * @param {object} org
+     * @returns {object}
+     */
     add (org) {
       this.data.push(org)
       return org
     },
-    getOrAdd (org_id, withDatasets = false) {
+    /**
+     * Get an org from the store or from the API if not cached
+     *
+     * @param {string} org_id
+     * @returns {object}
+     */
+    getOrAdd (org_id) {
       const existing = this.data.find(o => o.value.id === org_id || o.value.slug === org_id)
       if (existing) return existing.value
       const { data } = api.get(org_id)
-      if (withDatasets) this.getOrAddDatasetForOrg(org_id)
       return this.add(data)
     },
+    /**
+     * Get datasets for an org from the store or from the API ()
+     *
+     * @param {str} org_id
+     * @returns {object}
+     */
     getOrAddDatasetForOrg (org_id) {
       const dStore = useDatasetStore()
       return dStore.getOrAddDatasetsForOrg(org_id)

--- a/src/views/organizations/OrganizationDetailView.vue
+++ b/src/views/organizations/OrganizationDetailView.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useRoute } from "vue-router"
-import { computed } from "vue"
+import { computed, ref } from "vue"
 
 import { useOrganizationStore, useDatasetStore } from "../../store"
 
@@ -10,9 +10,15 @@ const organizationId = route.params.oid
 const orgStore = useOrganizationStore()
 const datasetStore = useDatasetStore()
 
-const fetchDatasets = true
-const org = orgStore.getOrAdd(organizationId, fetchDatasets)
-const datasets = computed(() => datasetStore.datasetsForOrg(organizationId))
+const org = orgStore.getOrAdd(organizationId)
+
+const currentPage = ref(1)
+const pages = computed(() => datasetStore.getDatasetsPaginationForOrg(organizationId))
+const datasets = computed(() => datasetStore.getOrAddDatasetsForOrg(organizationId, currentPage.value))
+
+function onUpdatePage (page) {
+  currentPage.value = page + 1
+}
 </script>
 
 <template>
@@ -20,6 +26,7 @@ const datasets = computed(() => datasetStore.datasetsForOrg(organizationId))
   <div>{{ org.description }}</div>
   <h2>Jeux de données</h2>
   <ul>
-    <li v-for="d in datasets">{{ d.title }}</li>
+    <li v-for="d in datasets.data">{{ d.title }}</li>
   </ul>
+  <DsfrPagination v-if="pages.length" :current-page="currentPage - 1" :pages="pages" @update:current-page="onUpdatePage" />
 </template>

--- a/src/views/organizations/OrganizationsListView.vue
+++ b/src/views/organizations/OrganizationsListView.vue
@@ -1,23 +1,23 @@
 <script setup>
-import { useOrganizationStore } from "../../store";
+import { useOrganizationStore } from "../../store"
+import Card from "../../components/Card.vue"
 
 const store = useOrganizationStore()
 const organizations = store.fillFromConfig()
 </script>
 
 <template>
-  <div v-for="org in organizations">
-    <!-- we're using `.value` here since api.data is a ref wrapped in a ref (?) -->
-    <DsfrCard
-      style="max-width: 400px;"
-      :alt-img="org.value.name"
-      :detail="org.value.acronym"
-      :description="org.value.description"
-      :img-src="org.value.logo"
-      :link="`/organizations/${org.value.slug}`"
-      :title="org.value.name"
-      :horizontal="false"
-      :no-arrow="false"
-    />
+  <div class="fr-container--fluid fr-mt-4w fr-mb-4w">
+    <div class="fr-grid-row fr-grid-row--gutters">
+      <!-- we're using `.value` here since api.data is a ref wrapped in a ref (?) -->
+      <Card v-for="org in organizations"
+        class="fr-col-5 fr-m-2w"
+        :alt-img="org.value.name"
+        :link="`/organizations/${org.value.slug}`"
+        :title="org.value.name"
+        :description="org.value.description"
+        :img="org.value.logo"
+      />
+    </div>
   </div>
 </template>

--- a/src/views/organizations/OrganizationsListView.vue
+++ b/src/views/organizations/OrganizationsListView.vue
@@ -1,9 +1,17 @@
 <script setup>
+import { ref, computed } from "vue"
 import { useOrganizationStore } from "../../store"
 import Card from "../../components/Card.vue"
 
 const store = useOrganizationStore()
-const organizations = store.fillFromConfig()
+
+const currentPage = ref(1)
+const pages = store.getPagination()
+const organizations = computed(() => store.getOrAddListFromConfig(currentPage.value))
+
+function onUpdatePage (page) {
+  currentPage.value = page + 1
+}
 </script>
 
 <template>
@@ -20,4 +28,5 @@ const organizations = store.fillFromConfig()
       />
     </div>
   </div>
+  <DsfrPagination v-if="pages.length" :current-page="currentPage - 1" :pages="pages" @update:current-page="onUpdatePage" />
 </template>


### PR DESCRIPTION
Due to the new config file #9, it became necessary to paginate organizations and datasets.

This PR also introduces a clean(ish) organizations list page with custom cards (vue-dsfr ones too limited) and a (dumb) loading state overlay since we're now making a lot more requests.