### PR TITLE
Dataset detail page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@gouvminint/vue-dsfr": "^3.6.0",
         "axios": "^1.4.0",
+        "marked": "^5.1.0",
         "pinia": "^2.1.4",
         "vue": "^3.3.4",
         "vue-loading-overlay": "^6.0.3",
@@ -1733,6 +1734,17 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/marked": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-5.1.0.tgz",
+      "integrity": "sha512-z3/nBe7aTI8JDszlYLk7dDVNpngjw0o1ZJtrA9kIfkkHcIF+xH7mO23aISl4WxP83elU+MFROgahqdpd05lMEQ==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mime-db": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@gouvminint/vue-dsfr": "^3.6.0",
         "axios": "^1.4.0",
+        "filesize": "^10.0.7",
         "marked": "^5.1.0",
         "pinia": "^2.1.4",
         "vue": "^3.3.4",
@@ -28,6 +29,15 @@
         "prettier": "^2.8.8",
         "sass": "^1.63.6",
         "vite": "^4.3.9"
+      }
+    },
+    "node_modules/@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@babel/parser": {
@@ -1358,6 +1368,14 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/filesize": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.0.7.tgz",
+      "integrity": "sha512-iMRG7Qo9nayLoU3PNCiLizYtsy4W1ClrapeCwEgtiQelOAOuRJiw4QaLI+sSr8xr901dgHv+EYP2bCusGZgoiA==",
+      "engines": {
+        "node": ">= 10.4.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -1880,17 +1898,17 @@
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
       "dev": true,
       "dependencies": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "type-check": "^0.4.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -2552,15 +2570,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@gouvminint/vue-dsfr": "^3.6.0",
     "axios": "^1.4.0",
+    "marked": "^5.1.0",
     "pinia": "^2.1.4",
     "vue": "^3.3.4",
     "vue-loading-overlay": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@gouvminint/vue-dsfr": "^3.6.0",
     "axios": "^1.4.0",
+    "filesize": "^10.0.7",
     "marked": "^5.1.0",
     "pinia": "^2.1.4",
     "vue": "^3.3.4",

--- a/src/composables/fetch.js
+++ b/src/composables/fetch.js
@@ -1,25 +1,24 @@
 import axios from 'axios'
-import { ref } from 'vue'
 
 /**
- * @typedef {object} ComposableFetchResult
- * @property {ref} data
- * @property {ref} error
+ * HTTP-fetch an URL
  *
  * @param {string} url
- * @param {function?} cb
- * @returns {ComposableFetchResult}
+ * @param {function?} onError
+ * @param {function?} onFinally
+ * @returns {object}
  */
-export function useFetch(url, cb) {
-  const data = ref({})
-  const error = ref(null)
-
-  axios.get(url)
-    .then((res) => data.value = res.data)
-    .catch((err) => (error.value = err))
-    .finally(() => {
-      if (cb) cb()
-    })
-
-  return { data, error }
+export async function useFetch(url, onError, onFinally) {
+  try {
+    const res = await axios.get(url)
+    return res.data
+  } catch (error) {
+    if (onError) {
+      onError(error)
+    } else {
+      throw error
+    }
+  } finally {
+    if (onFinally) onFinally()
+  }
 }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from "vue-router"
 import HomeView from "../views/HomeView.vue"
 import OrganizationsListView from "../views/organizations/OrganizationsListView.vue"
 import OrganizationDetailView from "../views/organizations/OrganizationDetailView.vue"
+import DatasetDetailView from "../views/datasets/DatasetDetailView.vue"
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -30,13 +31,17 @@ const router = createRouter({
     {
       path: "/datasets/:did",
       name: "dataset_detail",
-      // TODO:
-      component: () => import("../views/AboutView.vue"),
+      component: DatasetDetailView,
     },
     {
       path: "/about",
       name: "about",
       component: () => import("../views/AboutView.vue"),
+    },
+    {
+      path: "/playground",
+      name: "playground",
+      component: () => import("../playground/Component.vue"),
     },
   ],
 })

--- a/src/services/api/DatagouvfrAPI.js
+++ b/src/services/api/DatagouvfrAPI.js
@@ -29,16 +29,13 @@ export default class DatagouvfrAPI {
    * @param {string} url
    * @returns {import("../../composables/fetch").ComposableFetchResult}
    */
-  makeRequestAndHandleResponse (url) {
+  async makeRequestAndHandleResponse (url) {
     const loader = $loading.show()
-    const { data, error } = useFetch(url, () => loader.hide())
-    // TODO: unwatch when request is done?
-    watch(error, (errorValue) => {
-      if (errorValue && errorValue.message) {
-        toast(errorValue.message, {type: "error", autoClose: false})
+    return await useFetch(url, (error) => {
+      if (error && error.message) {
+        toast(error.message, {type: "error", autoClose: false})
       }
-    })
-    return { data, error }
+    }, () => loader.hide())
   }
 
   /**
@@ -47,9 +44,9 @@ export default class DatagouvfrAPI {
    * @param {string} entity_id
    * @returns {import("../../composables/fetch").ComposableFetchResult}
    */
-  get (entity_id) {
+  async get (entity_id) {
     const url = `${this.url()}/${entity_id}/`
-    return this.makeRequestAndHandleResponse(url)
+    return await this.makeRequestAndHandleResponse(url)
   }
 
   /**
@@ -57,7 +54,7 @@ export default class DatagouvfrAPI {
    *
    * @returns {import("../../composables/fetch").ComposableFetchResult}
    */
-  list () {
-    return this.makeRequestAndHandleResponse(this.url())
+  async list () {
+    return await this.makeRequestAndHandleResponse(this.url())
   }
 }

--- a/src/services/api/resources/DatasetsAPI.js
+++ b/src/services/api/resources/DatasetsAPI.js
@@ -1,0 +1,5 @@
+import DatagouvfrAPI from "../DatagouvfrAPI"
+
+export default class DatasetsAPI extends DatagouvfrAPI {
+  endpoint = "datasets"
+}

--- a/src/services/api/resources/OrganizationsAPI.js
+++ b/src/services/api/resources/OrganizationsAPI.js
@@ -7,10 +7,10 @@ export default class OrganizationsAPI extends DatagouvfrAPI {
    * Get datasets for an organization
    *
    * @param {str} org_id
-   * @returns {import("../../../composables/fetch").ComposableFetchResult}
+   * @returns {object}
    */
-  getDatasets (org_id, page = 1) {
+  async getDatasets (org_id, page = 1) {
     const url = `${this.url()}/${org_id}/datasets/?page=${page}`
-    return this.makeRequestAndHandleResponse(url)
+    return await this.makeRequestAndHandleResponse(url)
   }
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -89,10 +89,7 @@ export const useDatasetStore = defineStore("dataset", {
     get (dataset_id) {
       // flatten pages data for each organization
       // TODO: suboptimal store structure for this use case, see later if org oriented or flat is better
-      // TODO: try to simplify since no refs anymore
-      const flattened = Object.keys(this.data).map(org_id => {
-        return this.data[org_id].map(org_data => org_data.data)
-      }).reduce((flat, toFlatten) => flat.concat(toFlatten), []).flat()
+      const flattened = Object.keys(this.data).map(k => this.data[k].map(a => a.data).flat()).flat()
       return flattened.find(d => {
         return d.id === dataset_id || d.slug === dataset_id
       })

--- a/src/views/datasets/DatasetDetailView.vue
+++ b/src/views/datasets/DatasetDetailView.vue
@@ -1,0 +1,44 @@
+<script setup>
+import { marked } from "marked"
+
+import { useRoute } from "vue-router"
+
+import { useDatasetStore } from "../../store"
+import { computed } from "vue"
+
+const route = useRoute()
+const datasetId = route.params.did
+
+const store = useDatasetStore()
+const dataset = store.getOrAdd(datasetId)
+
+const files = computed(() => {
+  // FIXME: sometimes value, sometimes no value...
+  return dataset.value?.resources?.map(resource => {
+    return {
+      title: resource.title || "Fichier sans nom",
+      format: resource.format,
+      // TODO: convert to human readable
+      size: resource.filesize || "Taille inconnue",
+      href: resource.url,
+    }
+  })
+})
+
+const description = computed(() => {
+  // FIXME: sometimes value, sometimes no value...
+  if (dataset.value?.description) {
+    return marked.parse(dataset.value.description, {mangle: false, headerIds: false})
+  }
+})
+</script>
+
+<template>
+  <h1>{{ dataset.title }}</h1>
+  <div v-html="description"></div>
+  <DsfrFileDownloadList
+    class="fr-mt-4w"
+    :files="files"
+    title="Fichiers du jeu de données"
+  />
+</template>

--- a/src/views/datasets/DatasetDetailView.vue
+++ b/src/views/datasets/DatasetDetailView.vue
@@ -1,35 +1,43 @@
 <script setup>
 import { marked } from "marked"
+import { filesize } from "filesize"
 
 import { useRoute } from "vue-router"
 
 import { useDatasetStore } from "../../store"
-import { computed } from "vue"
+import { computed, onMounted } from "vue"
 
 const route = useRoute()
 const datasetId = route.params.did
 
 const store = useDatasetStore()
-const dataset = store.getOrAdd(datasetId)
+
+const dataset = computed(() => store.get(datasetId) || {})
+
+const formatFileSize = (fileSize) => {
+  if (!fileSize) return "Taille inconnue"
+  return filesize(fileSize)
+}
 
 const files = computed(() => {
-  // FIXME: sometimes value, sometimes no value...
   return dataset.value?.resources?.map(resource => {
     return {
       title: resource.title || "Fichier sans nom",
       format: resource.format,
-      // TODO: convert to human readable
-      size: resource.filesize || "Taille inconnue",
+      size: formatFileSize(resource.filesize),
       href: resource.url,
     }
   })
 })
 
 const description = computed(() => {
-  // FIXME: sometimes value, sometimes no value...
   if (dataset.value?.description) {
     return marked.parse(dataset.value.description, {mangle: false, headerIds: false})
   }
+})
+
+onMounted(() => {
+  store.load(datasetId)
 })
 </script>
 

--- a/src/views/organizations/OrganizationDetailView.vue
+++ b/src/views/organizations/OrganizationDetailView.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useRoute } from "vue-router"
-import { computed, ref } from "vue"
+import { computed, onMounted, ref } from "vue"
 
 import { useOrganizationStore, useDatasetStore } from "../../store"
 import Card from "../../components/Card.vue"
@@ -11,15 +11,21 @@ const organizationId = route.params.oid
 const orgStore = useOrganizationStore()
 const datasetStore = useDatasetStore()
 
-const org = orgStore.getOrAdd(organizationId)
+const org = computed(() => orgStore.get(organizationId) || {})
 
 const currentPage = ref(1)
 const pages = computed(() => datasetStore.getDatasetsPaginationForOrg(organizationId))
-const datasets = computed(() => datasetStore.getOrAddDatasetsForOrg(organizationId, currentPage.value))
+const datasets = computed(() => datasetStore.getDatasetsForOrg(organizationId, currentPage.value))
 
 function onUpdatePage (page) {
   currentPage.value = page + 1
+  datasetStore.loadDatasetsForOrg(organizationId, currentPage.value)
 }
+
+onMounted(() => {
+  orgStore.load(organizationId)
+  datasetStore.loadDatasetsForOrg(organizationId)
+})
 </script>
 
 <template>

--- a/src/views/organizations/OrganizationsListView.vue
+++ b/src/views/organizations/OrganizationsListView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed } from "vue"
+import { ref, computed, onMounted } from "vue"
 import { useOrganizationStore } from "../../store"
 import Card from "../../components/Card.vue"
 
@@ -7,24 +7,28 @@ const store = useOrganizationStore()
 
 const currentPage = ref(1)
 const pages = store.getPagination()
-const organizations = computed(() => store.getOrAddListFromConfig(currentPage.value))
+const organizations = computed(() => store.getForPage(currentPage.value))
 
 function onUpdatePage (page) {
   currentPage.value = page + 1
+  store.loadFromConfig(currentPage.value)
 }
+
+onMounted(() => {
+  store.loadFromConfig()
+})
 </script>
 
 <template>
   <div class="fr-container--fluid fr-mt-4w fr-mb-4w">
     <div class="fr-grid-row fr-grid-row--gutters">
-      <!-- we're using `.value` here since api.data is a ref wrapped in a ref (?) -->
       <Card v-for="org in organizations"
         class="fr-col-5 fr-m-2w"
-        :alt-img="org.value.name"
-        :link="`/organizations/${org.value.slug}`"
-        :title="org.value.name"
-        :description="org.value.description"
-        :img="org.value.logo"
+        :alt-img="org.name"
+        :link="`/organizations/${org.slug}`"
+        :title="org.name"
+        :description="org.description"
+        :img="org.logo"
       />
     </div>
   </div>


### PR DESCRIPTION
Adds a dataset detail page.

A pretty big refactoring was needed at the API wrapper level since working with `ref()`s nested at different level (fetching a single dataset from the API vs extracting it from organization data) was becoming a nightmare.

The new async/await logic is cleaner IMHO, yet a bit more verbose in components.

New logic:
- stores have async `load*()` methods that trigger API calls that can be awaited, to be called on `onMounted()` and when something changes, eg the page being viewed
- stores have dynamic synchronous getters `get*()` on the results of the API calls and parameters such as page