### PR TITLE
Filter archived datasets

### DIFF
--- a/src/services/api/resources/DatasetsAPI.js
+++ b/src/services/api/resources/DatasetsAPI.js
@@ -2,4 +2,17 @@ import DatagouvfrAPI from "../DatagouvfrAPI"
 
 export default class DatasetsAPI extends DatagouvfrAPI {
   endpoint = "datasets"
+
+  /**
+   * Get datasets for an organization
+   *
+   * @param {str} org_id Technical org id
+   * @returns {object}
+   */
+  async getDatasetsForOrganization (org_id, page = 1) {
+    // WARNING: specify `-created` or another sort explicitely because default sort has a pagination issue
+    const url = `${this.url()}/?organization=${org_id}&page=${page}&sort=-created`
+    return await this.makeRequestAndHandleResponse(url)
+  }
+
 }

--- a/src/services/api/resources/OrganizationsAPI.js
+++ b/src/services/api/resources/OrganizationsAPI.js
@@ -2,15 +2,4 @@ import DatagouvfrAPI from "../DatagouvfrAPI"
 
 export default class OrganizationsAPI extends DatagouvfrAPI {
   endpoint = "organizations"
-
-  /**
-   * Get datasets for an organization
-   *
-   * @param {str} org_id
-   * @returns {object}
-   */
-  async getDatasets (org_id, page = 1) {
-    const url = `${this.url()}/${org_id}/datasets/?page=${page}`
-    return await this.makeRequestAndHandleResponse(url)
-  }
 }

--- a/src/store/DatasetStore.js
+++ b/src/store/DatasetStore.js
@@ -3,7 +3,6 @@ import DatasetsAPI from "../services/api/resources/DatasetsAPI"
 import OrganizationsAPI from "../services/api/resources/OrganizationsAPI"
 
 const datasetsApi = new DatasetsAPI()
-const orgApi = new OrganizationsAPI()
 
 /**
  * An organization oriented and paginated store for datasets
@@ -63,7 +62,7 @@ export const useDatasetStore = defineStore("dataset", {
     async loadDatasetsForOrg (org_id, page = 1) {
       const existing = this.getDatasetsForOrg(org_id, page)
       if (existing.data) return existing
-      const datasets = await orgApi.getDatasets(org_id, page)
+      const datasets = await datasetsApi.getDatasetsForOrganization(org_id, page)
       this.addDatasets(org_id, datasets)
       return this.getDatasetsForOrg(org_id, page)
     },


### PR DESCRIPTION
Use another endpoint to fetch an organization's datasets which does not include archived datasets.

We need the organization technical id for this endpoint, so the fetch logic is a bit more convoluted.