### PR TITLE
Search improvements

### DIFF
--- a/src/services/api/SearchAPI.js
+++ b/src/services/api/SearchAPI.js
@@ -1,4 +1,7 @@
 import { MeiliSearch } from "meilisearch"
+import { useLoading } from 'vue-loading-overlay'
+
+const $loading = useLoading()
 
 /**
  * A wrapper around search engine API
@@ -8,6 +11,13 @@ export default class SearchAPI {
     const host = import.meta.env.VITE_SEARCH_ENGINE_URL
     const apiKey = import.meta.env.VITE_SEARCH_ENGINE_PUBLIC_KEY
     const client = new MeiliSearch({host, apiKey})
-    return client.index("datasets")
+    this.index = client.index("datasets")
+  }
+
+  search (query, args) {
+    const loader = $loading.show()
+    return this.index.search(query, args).catch(err => {
+      toast(err.message, {type: "error", autoClose: false})
+    }).finally(() => loader.hide())
   }
 }

--- a/src/services/api/SearchAPI.js
+++ b/src/services/api/SearchAPI.js
@@ -1,5 +1,6 @@
 import { MeiliSearch } from "meilisearch"
 import { useLoading } from 'vue-loading-overlay'
+import { toast } from "vue3-toastify"
 
 const $loading = useLoading()
 

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -10,6 +10,9 @@ export const useSearchStore = defineStore("search", {
     data: {}
   }),
   getters: {
+    facets: (state) => {
+      return state.data.facetDistribution || {}
+    },
     datasets: (state) => {
       return state.data.hits || []
     },
@@ -26,8 +29,8 @@ export const useSearchStore = defineStore("search", {
     },
   },
   actions: {
-    async search (query, page = 1) {
-      const args = { hitsPerPage: pageSize, facets: ["organization.name"], page: page }
+    async search (query, page = 1, filter = []) {
+      const args = { hitsPerPage: pageSize, facets: ["organization.name"], page: page, filter: filter}
       const results = await searchAPI.search(query, args)
       this.data = results
     }

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -3,14 +3,32 @@ import { defineStore } from "pinia"
 import SearchAPI from "../services/api/SearchAPI"
 
 const searchAPI = new SearchAPI()
+const pageSize = 21
 
 export const useSearchStore = defineStore("search", {
   state: () => ({
-    data: []
+    data: {}
   }),
+  getters: {
+    datasets: (state) => {
+      return state.data.hits || []
+    },
+    pagination: (state) => {
+      if (!state.data) return []
+      return [...Array(state.data.totalPages).keys()].map(page => {
+        page += 1
+        return {
+          label: page,
+          href: "#",
+          title: `Page ${page}`,
+        }
+      })
+    },
+  },
   actions: {
-    async search (query) {
-      const results = await searchAPI.search(query, {hitsPerPage: 21})
+    async search (query, page = 1) {
+      const args = { hitsPerPage: pageSize, facets: ["organization.name"], page: page }
+      const results = await searchAPI.search(query, args)
       this.data = results
     }
   },

--- a/src/views/datasets/DatasetsListView.vue
+++ b/src/views/datasets/DatasetsListView.vue
@@ -1,21 +1,24 @@
 <script setup>
-import { computed, onMounted, watch } from "vue"
-import { useRoute } from "vue-router"
+import { computed, ref, watchEffect } from "vue"
+import { useRoute, onBeforeRouteUpdate } from "vue-router"
 import Tile from "../../components/Tile.vue"
 import { useSearchStore } from "../../store/SearchStore"
 
 const route = useRoute()
 const store = useSearchStore()
 const query = computed(() => route.query.q)
+const currentPage = ref(1)
 
-const datasets = computed(() => store.$state.data.hits)
+const datasets = computed(() => store.datasets)
+const pages = computed(() => store.pagination)
 
-watch(query, _query => {
-  store.search(_query)
+// reset currentPage when query changes
+onBeforeRouteUpdate((to, from) => {
+  currentPage.value = 1
 })
 
-onMounted(() => {
-  store.search(query.value)
+watchEffect(() => {
+  store.search(query.value, currentPage.value)
 })
 </script>
 
@@ -35,4 +38,5 @@ onMounted(() => {
       </li>
     </ul>
   </div>
+  <DsfrPagination v-if="pages.length" :current-page="currentPage - 1" :pages="pages" @update:current-page="p => currentPage = p + 1" />
 </template>

--- a/src/views/datasets/DatasetsListView.vue
+++ b/src/views/datasets/DatasetsListView.vue
@@ -23,6 +23,7 @@ onMounted(() => {
   <div class="fr-container--fluid fr-mt-4w fr-mb-4w">
     <h2 v-if="query">Résultats de recherche pour "{{ query }}"</h2>
     <h2 v-else>Jeux de données</h2>
+    <div class="fr-mb-4w" v-if="query && datasets?.length === 0">Aucun résultat pour cette recherche.</div>
     <ul class="fr-grid-row fr-grid-row--gutters es__tiles__list">
       <li v-for="d in datasets" class="fr-col-12 fr-col-lg-4">
         <Tile

--- a/src/views/datasets/DatasetsListView.vue
+++ b/src/views/datasets/DatasetsListView.vue
@@ -20,9 +20,8 @@ const orgFacets = computed(() => {
     return {
       text: `${k} (${count})`,
       value: k,
-      count,
     }
-  }).sort((a, b) => b.count - a.count)
+  }).sort((a, b) => a.value - b.value)
 })
 
 const filterSearch = (filterKey, filterValue) => {

--- a/src/views/datasets/DatasetsListView.vue
+++ b/src/views/datasets/DatasetsListView.vue
@@ -9,22 +9,35 @@ const store = useSearchStore()
 const query = computed(() => route.query.q)
 const currentPage = ref(1)
 const searchFilter = ref([])
+const selectedOrg = ref(null)
 
 const datasets = computed(() => store.datasets)
 const pages = computed(() => store.pagination)
 
 const orgFacets = computed(() => {
   return Object.keys(store.facets["organization.name"] || {}).map(k => {
-    return {count: store.facets["organization.name"][k], value: k}
+    const count = store.facets["organization.name"][k]
+    return {
+      text: `${k} (${count})`,
+      value: k,
+      count,
+    }
   }).sort((a, b) => b.count - a.count)
 })
 
 const filterSearch = (filterKey, filterValue) => {
+  if (!filterValue) return
   searchFilter.value = [`${filterKey} = "${filterValue}"`]
+}
+
+const onSelectOrg = (value) => {
+  selectedOrg.value = value
+  filterSearch("organization.name", value)
 }
 
 const resetFilter = () => {
   searchFilter.value = []
+  selectedOrg.value = null
 }
 
 // reset currentPage when query changes
@@ -44,14 +57,15 @@ watchEffect(() => {
     <h2 v-else>Jeux de données</h2>
     <div class="fr-mb-4w" v-if="query && datasets?.length === 0">Aucun résultat pour cette recherche.</div>
     <div class="fr-grid-row">
-      <div class="fr-col-md-3">
-        <ul>
-          <li v-for="facet in orgFacets">
-            <a href="#" @click.prevent="filterSearch('organization.name', facet.value)">{{ facet.value }} ({{ facet.count }})</a>
-          </li>
-        </ul>
+      <div class="fr-col-md-4 fr-pr-md-2w fr-mb-2w">
+        <div class="fr-mb-2w">
+          <a href="#" :click.prevent.stop="resetFilter" v-if="selectedOrg">x Effacer les filtres</a>
+        </div>
+        <DsfrSelect :options="orgFacets" :model-value="selectedOrg" @update:modelValue="onSelectOrg">
+          <template #label>Organisation</template>
+        </DsfrSelect>
       </div>
-      <div class="fr-col-md-9">
+      <div class="fr-col-md-8">
         <ul class="fr-grid-row fr-grid-row--gutters es__tiles__list">
           <li v-for="d in datasets" class="fr-col-12 fr-col-lg-4">
             <Tile
@@ -64,7 +78,6 @@ watchEffect(() => {
         </ul>
       </div>
     </div>
-
   </div>
   <DsfrPagination v-if="pages.length" :current-page="currentPage - 1" :pages="pages" @update:current-page="p => currentPage = p + 1" />
 </template>


### PR DESCRIPTION
Adds pagination and organization facet to search page.

Needs https://github.com/ecolabdata/ecospheres-search-index/pull/2, which also implements a default sort.

I used a select for the organization facet, which is not optimal but there's no autocomplete component (for example) in DSFR.