### PR TITLE
Basic support for data.gouv.fr oauth

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,7 @@ datagouvfr_base_url: https://demo.data.gouv.fr
 
 # oauth settings
 datagouvfr_oauth_client_id: 651479c317ad47b21e41a9d4
+# pkce client secret, explicitely public
 datagouvfr_oauth_client_secret: v4ohcEhC4vEq8SpOl7tOiEXZfW1JSej1QpsH4oec4Gn11hCxUF
 
 # display settings

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,11 @@
 # config file for ecospheres-front
 
-# data.gouv.fr API base URL
-datagouvfr_api_url: https://www.data.gouv.fr/api
+# data.gouv.fr base URL
+datagouvfr_base_url: https://demo.data.gouv.fr
+
+# oauth settings
+datagouvfr_oauth_client_id: 651479c317ad47b21e41a9d4
+datagouvfr_oauth_client_secret: v4ohcEhC4vEq8SpOl7tOiEXZfW1JSej1QpsH4oec4Gn11hCxUF
 
 # display settings
 organizations_list_page_size: 9

--- a/src/App.vue
+++ b/src/App.vue
@@ -42,8 +42,9 @@ onMounted(() => {
       if (err.response?.status === 401) {
         store.logout()
         localStorage.setItem("lastPath", router.currentRoute.value.path)
-        router.push({name: "login"})
+        return router.push({name: "login"})
       }
+      throw err
     })
   }
 })

--- a/src/App.vue
+++ b/src/App.vue
@@ -34,9 +34,15 @@ const doSearch = () => {
 onMounted(() => {
   store.init()
   if (isLoggedIn.value) {
-    // TODO: redirect to login if this fails (token expired)
     api.getProfile().then(data => {
       store.storeInfo(data)
+    }).catch(() => {
+      // getProfile has failed, we're probably using a bad token
+      // keep the current route and redirect to the login flow
+      // TODO: handle this as a response interceptor on 401?
+      store.logout()
+      localStorage.setItem("lastPath", router.currentRoute.value.path)
+      router.push({name: "login"})
     })
   }
 })

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,7 +17,7 @@ const quickLinks = computed(() => {
     {
       label: isLoggedIn.value ? `${store.$state.data.first_name} ${store.$state.data.last_name}` : "Se connecter",
       icon: isLoggedIn.value ? "ri-logout-box-r-line" : "ri-account-circle-line",
-      to: isLoggedIn.value ? "logout" : "login",
+      to: isLoggedIn.value ? "/logout" : "/login",
       iconRight: isLoggedIn.value,
     }
   ]

--- a/src/App.vue
+++ b/src/App.vue
@@ -36,13 +36,14 @@ onMounted(() => {
   if (isLoggedIn.value) {
     api.getProfile().then(data => {
       store.storeInfo(data)
-    }).catch(() => {
+    }).catch(err => {
       // getProfile has failed, we're probably using a bad token
       // keep the current route and redirect to the login flow
-      // TODO: handle this as a response interceptor on 401?
-      store.logout()
-      localStorage.setItem("lastPath", router.currentRoute.value.path)
-      router.push({name: "login"})
+      if (err.response?.status === 401) {
+        store.logout()
+        localStorage.setItem("lastPath", router.currentRoute.value.path)
+        router.push({name: "login"})
+      }
     })
   }
 })

--- a/src/composables/fetch.js
+++ b/src/composables/fetch.js
@@ -1,4 +1,16 @@
-import axios from 'axios'
+import axios from "axios"
+import { useUserStore } from "../store/UserStore"
+
+// inject token in requests if user is loggedIn
+axios.interceptors.request.use(config => {
+  const store = useUserStore()
+  if (store.$state.isLoggedIn) {
+    config.headers = {
+      Authorization: `Bearer ${store.$state.token}`
+    }
+  }
+  return config
+}, error => Promise.reject(error))
 
 /**
  * HTTP-fetch an URL

--- a/src/composables/fetch.js
+++ b/src/composables/fetch.js
@@ -1,8 +1,10 @@
 import axios from "axios"
 import { useUserStore } from "../store/UserStore"
 
+const instance = axios.create()
+
 // inject token in requests if user is loggedIn
-axios.interceptors.request.use(config => {
+instance.interceptors.request.use(config => {
   const store = useUserStore()
   if (store.$state.isLoggedIn) {
     config.headers = {
@@ -22,7 +24,7 @@ axios.interceptors.request.use(config => {
  */
 export async function useFetch(url, onError, onFinally) {
   try {
-    const res = await axios.get(url)
+    const res = await instance.get(url)
     return res.data
   } catch (error) {
     if (onError) {

--- a/src/icons.js
+++ b/src/icons.js
@@ -1,0 +1,1 @@
+export { RiLogoutBoxRLine } from "oh-vue-icons/icons/ri/index.js"

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ import { createPinia } from "pinia"
 import VueDsfr from "@gouvminint/vue-dsfr"   // Import (par défaut) de la bibliothèque
 import App from "./App.vue"
 import router from "./router"
+import * as icons from "./icons.js"
 
 import TextClamp from 'vue3-text-clamp'
 import { LoadingPlugin } from 'vue-loading-overlay'
@@ -17,7 +18,7 @@ const app = createApp(App)
 const pinia = createPinia()
 
 app.use(router)
-app.use(VueDsfr)
+app.use(VueDsfr, { icons: Object.values(icons) })
 app.use(pinia)
 
 app.use(TextClamp)

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -5,6 +5,7 @@ import OrganizationDetailView from "../views/organizations/OrganizationDetailVie
 import DatasetDetailView from "../views/datasets/DatasetDetailView.vue"
 import DatasetsListView from "../views/datasets/DatasetsListView.vue"
 import LoginView from "../views/LoginView.vue"
+import LogoutView from "../views/LogoutView.vue"
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -43,6 +44,11 @@ const router = createRouter({
       path: "/login/callback",
       name: "login_callback",
       component: LoginView,
+    },
+    {
+      path: "/logout",
+      name: "logout",
+      component: LogoutView,
     },
     {
       path: "/about",

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,6 +4,7 @@ import OrganizationsListView from "../views/organizations/OrganizationsListView.
 import OrganizationDetailView from "../views/organizations/OrganizationDetailView.vue"
 import DatasetDetailView from "../views/datasets/DatasetDetailView.vue"
 import DatasetsListView from "../views/datasets/DatasetsListView.vue"
+import LoginView from "../views/LoginView.vue"
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -32,6 +33,16 @@ const router = createRouter({
       path: "/datasets/:did",
       name: "dataset_detail",
       component: DatasetDetailView,
+    },
+    {
+      path: "/login",
+      name: "login",
+      component: LoginView,
+    },
+    {
+      path: "/login/callback",
+      name: "login_callback",
+      component: LoginView,
     },
     {
       path: "/about",

--- a/src/services/AuthService.js
+++ b/src/services/AuthService.js
@@ -48,6 +48,18 @@ export default class AuthService {
     })
   }
 
+  createBasicAuthHeader() {
+    const headerStr = btoa(`${this.clientId}:${this.clientSecret}`);
+    return { Authorization: `Basic ${headerStr}` };
+  }
+
+  /**
+   * Logout remote procedure
+   */
+  async logout (token) {
+    return await api.logout(token, this.createBasicAuthHeader())
+  }
+
   /**
    * Cleanup after login flow
    */

--- a/src/services/AuthService.js
+++ b/src/services/AuthService.js
@@ -1,0 +1,93 @@
+import config from "@/config"
+import OauthAPI from "./api/OauthAPI"
+
+const api = new OauthAPI()
+
+export default class AuthService {
+  constructor () {
+    this.clientSecret = config.datagouvfr_oauth_client_secret
+    this.clientId = config.datagouvfr_oauth_client_id
+    this.baseURL = config.datagouvfr_base_url
+    this.redirectURI = `${window.location.origin}/login/callback`
+  }
+
+  /**
+   * Compute data.gouv.fr URL to be redirected to for oauth authorization
+   */
+  async getRedirectURL () {
+    const codeVerifier = this.generateRandomString()
+    const codeChallenge = await this.pkceChallengeFromVerifier(codeVerifier)
+    const state = this.generateRandomString()
+    const redirectURI = encodeURIComponent(this.redirectURI)
+    const encodedState = encodeURIComponent(state)
+    const encodedCC = encodeURIComponent(codeChallenge)
+
+    localStorage.setItem("pkceCodeVerifier", codeVerifier)
+    localStorage.setItem("pkceState", state)
+
+    return `${this.baseURL}/oauth/authorize?redirect_uri=${redirectURI}&response_type=code&state=${encodedState}&client_id=${this.clientId}&scope=default&code_challenge=${encodedCC}&code_challenge_method=S256`
+  }
+
+  /**
+   * Retrive an oauth token from a verification code
+   */
+  async retrieveToken (code, state) {
+    const storedState = localStorage.getItem("pkceState")
+    if (state != storedState) {
+      const error = `Unmatching states: ${state} vs ${storedState}`
+      console.error(error)
+      throw new Error(error)
+    }
+    const pkceCodeVerifier = localStorage.getItem("pkceCodeVerifier")
+    return await api.token({
+      code,
+      pkceCodeVerifier,
+      clientId: this.clientId,
+      clientSecret: this.clientSecret,
+      redirectURI: this.redirectURI,
+    })
+  }
+
+  /**
+   * Cleanup after login flow
+   */
+  cleanup () {
+    localStorage.removeItem("pkceCodeVerifier")
+    localStorage.removeItem("pkceState")
+  }
+
+  /**
+   * Utils functions
+   * see https://github.com/aaronpk/pkce-vanilla-js/blob/master/index.html
+   *
+   * This avoids using bloated and/or potentially unsafe packages for crypto features
+   *
+   */
+
+  generateRandomString () {
+    const array = new Uint32Array(28)
+    window.crypto.getRandomValues(array)
+    return Array.from(array, (dec) => (`0${dec.toString(16)}`).substr(-2)).join("")
+  }
+
+  createBasicAuthHeader () {
+    const headerStr = btoa(`${this.clientId}:${this.clientSecret}`)
+    return { Authorization: `Basic ${headerStr}` }
+  }
+
+  sha256 (plain) {
+    const encoder = new TextEncoder();
+    const data = encoder.encode(plain);
+    return window.crypto.subtle.digest("SHA-256", data)
+  }
+
+  base64urlencode (str) {
+    return btoa(String.fromCharCode.apply(null, new Uint8Array(str)))
+        .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+  }
+
+  async pkceChallengeFromVerifier(v) {
+    const hashed = await this.sha256(v);
+    return this.base64urlencode(hashed);
+  }
+}

--- a/src/services/AuthService.js
+++ b/src/services/AuthService.js
@@ -74,6 +74,30 @@ export default class AuthService {
    *
    * This avoids using bloated and/or potentially unsafe packages for crypto features
    *
+   * TODO: merge the copyright with our own if we use a MIT license
+   *
+   * MIT License
+   *
+   * Copyright (c) 2019 Aaron Parecki
+   *
+   * Permission is hereby granted, free of charge, to any person obtaining a copy
+   * of this software and associated documentation files (the "Software"), to deal
+   * in the Software without restriction, including without limitation the rights
+   * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   * copies of the Software, and to permit persons to whom the Software is
+   * furnished to do so, subject to the following conditions:
+
+   * The above copyright notice and this permission notice shall be included in all
+   * copies or substantial portions of the Software.
+   *
+   * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   * SOFTWARE.
+   *
    */
 
   generateRandomString () {
@@ -102,4 +126,8 @@ export default class AuthService {
     const hashed = await this.sha256(v);
     return this.base64urlencode(hashed);
   }
+
+  /*
+   * end util functions
+   **/
 }

--- a/src/services/api/DatagouvfrAPI.js
+++ b/src/services/api/DatagouvfrAPI.js
@@ -14,7 +14,7 @@ const $loading = useLoading()
  * e.g. OrganizationsAPI will declare `endpoint = organizations`.
  */
 export default class DatagouvfrAPI {
-  base_url = config.datagouvfr_api_url
+  base_url = `${config.datagouvfr_base_url}/api`
   version = "1"
   endpoint = ""
 

--- a/src/services/api/OauthAPI.js
+++ b/src/services/api/OauthAPI.js
@@ -29,6 +29,7 @@ export default class OauthAPI {
    * Logout API call
    *
    * @param {string} token
+   * @param {headers} object
    * @returns {object}
    */
   async logout (token, headers) {

--- a/src/services/api/OauthAPI.js
+++ b/src/services/api/OauthAPI.js
@@ -6,7 +6,7 @@ export default class OauthAPI {
    * Get a token after PKCE flow
    *
    * @param {object}
-   * @returns {object}
+   * @returns {string}
    */
   async token ({code, pkceCodeVerifier, clientId, clientSecret, redirectURI}) {
     const url = `${config.datagouvfr_base_url}/oauth/token`
@@ -23,5 +23,23 @@ export default class OauthAPI {
       data: bodyFormData,
     })
     return response.data.access_token
+  }
+
+  /**
+   * Logout API call
+   *
+   * @param {string} token
+   * @returns {object}
+   */
+  async logout (token, headers) {
+    const bodyFormData = new FormData()
+    bodyFormData.append("token", token)
+    const response = await axios({
+      method: "post",
+      url: `${config.datagouvfr_base_url}/oauth/revoke`,
+      data: bodyFormData,
+      headers: headers,
+    })
+    return response
   }
 }

--- a/src/services/api/OauthAPI.js
+++ b/src/services/api/OauthAPI.js
@@ -1,0 +1,27 @@
+import axios from "axios"
+import config from "@/config"
+
+export default class OauthAPI {
+  /**
+   * Get a token after PKCE flow
+   *
+   * @param {object}
+   * @returns {object}
+   */
+  async token ({code, pkceCodeVerifier, clientId, clientSecret, redirectURI}) {
+    const url = `${config.datagouvfr_base_url}/oauth/token`
+    const bodyFormData = new FormData()
+    bodyFormData.append("grant_type", "authorization_code")
+    bodyFormData.append("code", code)
+    bodyFormData.append("redirect_uri", redirectURI)
+    bodyFormData.append("client_id", clientId)
+    bodyFormData.append("client_secret", clientSecret)
+    bodyFormData.append("code_verifier", pkceCodeVerifier)
+    const response = await axios({
+      method: "post",
+      url,
+      data: bodyFormData,
+    })
+    return response.data.access_token
+  }
+}

--- a/src/services/api/resources/ReusesAPI.js
+++ b/src/services/api/resources/ReusesAPI.js
@@ -1,6 +1,6 @@
 import DatagouvfrAPI from "../DatagouvfrAPI"
 
-export default class DatasetsAPI extends DatagouvfrAPI {
+export default class ReusesAPI extends DatagouvfrAPI {
   endpoint = "reuses"
 
   /**

--- a/src/services/api/resources/UserAPI.js
+++ b/src/services/api/resources/UserAPI.js
@@ -1,0 +1,14 @@
+import DatagouvfrAPI from "../DatagouvfrAPI"
+
+export default class UserAPI extends DatagouvfrAPI {
+  endpoint = "me"
+
+  /**
+   * Get currently logged-in user infos
+   *
+   * @returns {object}
+   */
+  async getProfile () {
+    return await this.makeRequestAndHandleResponse(`${this.url()}/`)
+  }
+}

--- a/src/services/api/resources/UserAPI.js
+++ b/src/services/api/resources/UserAPI.js
@@ -1,3 +1,4 @@
+import { useFetch } from "../../../composables/fetch"
 import DatagouvfrAPI from "../DatagouvfrAPI"
 
 export default class UserAPI extends DatagouvfrAPI {
@@ -5,10 +6,12 @@ export default class UserAPI extends DatagouvfrAPI {
 
   /**
    * Get currently logged-in user infos
+   * Does not use wrapped makeRequestAndHandleResponse to be able
+   * to respond on errors
    *
    * @returns {object}
    */
   async getProfile () {
-    return await this.makeRequestAndHandleResponse(`${this.url()}/`)
+    return await useFetch(`${this.url()}/`)
   }
 }

--- a/src/store/UserStore.js
+++ b/src/store/UserStore.js
@@ -1,6 +1,9 @@
 import { defineStore } from "pinia"
 
 // FIXME: we cant use UserAPI here (circular dep?)
+// maybe try to use the service that will use the API
+
+const STORAGE_KEY = "token"
 
 export const useUserStore = defineStore("user", {
   state: () => ({
@@ -13,7 +16,7 @@ export const useUserStore = defineStore("user", {
      * Init store from localStorage
      */
     init () {
-      const token = localStorage.getItem("token")
+      const token = localStorage.getItem(STORAGE_KEY)
       if (token) {
         this.token = token
         this.isLoggedIn = true
@@ -25,7 +28,16 @@ export const useUserStore = defineStore("user", {
     login (token) {
       this.isLoggedIn = true
       this.token = token
-      localStorage.setItem("token", token)
+      localStorage.setItem(STORAGE_KEY, token)
+    },
+    /**
+     * Reflet logged-out state
+     */
+    logout () {
+      this.isLoggedIn = false
+      this.token = undefined
+      this.data = {}
+      localStorage.removeItem(STORAGE_KEY)
     },
     /**
      * Store user infos

--- a/src/store/UserStore.js
+++ b/src/store/UserStore.js
@@ -1,0 +1,37 @@
+import { defineStore } from "pinia"
+
+// FIXME: we cant use UserAPI here (circular dep?)
+
+export const useUserStore = defineStore("user", {
+  state: () => ({
+    isLoggedIn: false,
+    data: {},
+    token: undefined,
+  }),
+  actions: {
+    /**
+     * Init store from localStorage
+     */
+    init () {
+      const token = localStorage.getItem("token")
+      if (token) {
+        this.token = token
+        this.isLoggedIn = true
+      }
+    },
+    /**
+     * Store user info after login
+     */
+    login (token) {
+      this.isLoggedIn = true
+      this.token = token
+      localStorage.setItem("token", token)
+    },
+    /**
+     * Store user infos
+     */
+    storeInfo (data) {
+      this.data = data
+    },
+  },
+})

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -24,7 +24,10 @@ onMounted(() => {
       api.getProfile().then(data => {
         store.storeInfo(data)
       })
-      router.push({name: "home"})
+      const lastPath = localStorage.getItem("lastPath")
+      const next = lastPath ? {path: lastPath} : {name: "home"}
+      localStorage.removeItem("lastPath")
+      router.push(next)
     })
   } else {
     console.log("Logged in!")

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -1,0 +1,40 @@
+<script setup>
+import { onMounted } from "vue"
+import { useRoute, useRouter } from "vue-router"
+import { useUserStore } from "../store/UserStore"
+import AuthService from "../services/AuthService"
+import UserAPI from "../services/api/resources/UserAPI"
+
+const route = useRoute()
+const router = useRouter()
+const store = useUserStore()
+const auth = new AuthService()
+const api = new UserAPI()
+
+onMounted(() => {
+  if (!store.$state.isLoggedIn && !route.query.code) {
+    auth.getRedirectURL().then(url => {
+      window.location.href = url
+    })
+  } else if (route.query.code) {
+    // Exchange the authorization code for an access token
+    auth.retrieveToken(route.query.code, route.query.state).then(token => {
+      auth.cleanup()
+      store.login(token)
+      api.getProfile().then(data => {
+        store.storeInfo(data)
+      })
+      router.push({name: "home"})
+    })
+  } else {
+    console.log("Logged in!")
+    router.push({name: "home"})
+  }
+})
+</script>
+
+<template>
+  <div class="about">
+    <h1>This is a login page</h1>
+  </div>
+</template>

--- a/src/views/LogoutView.vue
+++ b/src/views/LogoutView.vue
@@ -1,0 +1,29 @@
+<script setup>
+import { onMounted, computed } from "vue"
+import { useRouter } from "vue-router"
+import { useUserStore } from "../store/UserStore"
+import AuthService from "../services/AuthService"
+
+const router = useRouter()
+const store = useUserStore()
+const auth = new AuthService()
+const token = computed(() => store.$state.token)
+
+onMounted(() => {
+  if (token.value) {
+    auth.logout(token.value).then(() => {
+      store.logout()
+      console.log("Logged out")
+      router.push({name: "home"})
+    })
+  } else {
+    router.push({name: "home"})
+  }
+})
+</script>
+
+<template>
+  <div class="about">
+    <h1>This is a logout page</h1>
+  </div>
+</template>


### PR DESCRIPTION
This adds support for oauth connection on data.gouv.fr. You can login, logout and there's a crude detection for a bad token (expired) that will redirect you to the login flow. The header is responsive to your login state.

This also switches to demo.data.gouv.fr as a backend. https://github.com/ecolabdata/ecospheres-search-index will adapt to the config file when it's merged on main, but we'll need to reset the index in order not to mix prod and demo datasets.

NB: this won't work as a PR preview, the callback URL for oauth won't match. It works on local if you use the default port (5173).