### PR TITLE
User description when adding a dataset to a bouquet

### DIFF
--- a/src/components/Tile.vue
+++ b/src/components/Tile.vue
@@ -2,7 +2,10 @@
 import { computed } from "vue"
 import { stripFromMarkdown } from "../utils"
 
-const props = defineProps(["title", "description", "img", "link", "type", "externalLink", "isMarkdown"])
+const props = defineProps([
+  "title", "description", "img", "link", "type", "externalLink", "isMarkdown",
+  "notice"
+])
 
 const typeClass = computed(() => !!props.type && `es-card--${props.type}`)
 
@@ -32,5 +35,10 @@ function strip (value) {
     <div v-if="img" class="fr-tile__img">
       <img :src="img" class="fr-responsive-img" alt="">
     </div>
+    <DsfrNotice
+      v-if="notice"
+      :title="notice"
+      :closeable="false"
+    />
   </div>
 </template>

--- a/src/store/BouquetStore.js
+++ b/src/store/BouquetStore.js
@@ -15,7 +15,7 @@ export const useBouquetStore = defineStore("bouquet", {
      * @returns {Array}
      */
     filter (bouquets) {
-      return bouquets.filter(bouquet => bouquet.extras.is_ecospheres || bouquet.tags.includes("ecospheres"))
+      return bouquets.filter(bouquet => bouquet.tags.includes("ecospheres"))
     },
     /**
      * Load Ecospheres related bouquets from API

--- a/src/views/bouquets/BouquetDetailView.vue
+++ b/src/views/bouquets/BouquetDetailView.vue
@@ -47,6 +47,7 @@ onMounted(() => {
           :description="d.description"
           :img="d.organization.logo"
           :is-markdown="true"
+          :notice="bouquet.extras[`ecospheres:${d.id}:description`]"
         />
       </li>
     </ul>

--- a/src/views/bouquets/BouquetEditView.vue
+++ b/src/views/bouquets/BouquetEditView.vue
@@ -16,9 +16,31 @@ const isCreate = route.name === "bouquet_add"
 
 const form = ref({})
 const datasets = ref([])
-const selectedDataset = ref(null)
+const selectedDataset = ref({})
 const selector = ref(null)
 const loadedBouquet = ref({})
+const isModalOpen = ref(false)
+const isEditDesc = ref(false)
+
+const modalActions = [
+  {
+    label: "Valider",
+    onClick: (event) => {
+      event.preventDefault()
+      onSubmitModal()
+      isModalOpen.value = false
+    }
+  },
+  {
+    label: "Annuler",
+    secondary: true,
+    onClick: (event) => {
+      event.preventDefault()
+      isModalOpen.value = false
+      selectedDataset.value = {}
+    }
+  },
+]
 
 const search = async (query) => {
   if (!query) return []
@@ -28,43 +50,71 @@ const search = async (query) => {
   }).filter(r => !datasets.value.map(d => d.id).includes(r.value))
 }
 
-const onSelect = async (value) => {
-  const dataset = await datasetStore.load(value)
-  if (dataset) {
-    datasets.value.push(dataset)
+const onSubmitModal = async () => {
+  if (!selectedDataset.value.id) return
+  if (isEditDesc.value) {
+    const idx = datasets.value.findIndex(d => d.dataset.id === selectedDataset.value.id)
+    datasets.value[idx].description = selectedDataset.value.description
+  } else {
+    const dataset = await datasetStore.load(selectedDataset.value.id)
+    if (dataset) {
+      datasets.value.push({ dataset, description: selectedDataset.value.description })
+    }
   }
-  selector.value.clear()
-  selector.value.refreshOptions()
+  selectedDataset.value = {}
+  isEditDesc.value = false
 }
 
 const onDeleteDataset = (datasetId) => {
-  datasets.value = datasets.value.filter(d => d.id !== datasetId)
+  datasets.value = datasets.value.filter(d => d.dataset.id !== datasetId)
+  delete loadedBouquet.value.extras[`ecospheres:${datasetId}:description`]
+}
+
+const onEditDataset = (dataset) => {
+  isModalOpen.value = true
+  isEditDesc.value = true
+  selectedDataset.value.id = dataset.id
+  selectedDataset.value.title = dataset.title
+  selectedDataset.value.description = datasets.value.find(d => d.dataset.id === dataset.id).description
+}
+
+const extrasFromDatasets = () => {
+  const extras = {}
+  for (const dataset of datasets.value) {
+    extras[`ecospheres:${dataset.dataset.id}:description`] = dataset.description
+  }
+  return extras
 }
 
 const onSubmit = async () => {
   let res
   const data = {
     ...form.value,
-    datasets: datasets.value.map(d => d.id),
+    datasets: datasets.value.map(d => d.dataset.id),
   }
   if (isCreate) {
     res = await bouquetStore.create({
       ...data,
       tags: ["ecospheres"],
-      extras: { is_ecospheres: true },
+      extras: extrasFromDatasets(),
     })
   } else {
     res = await bouquetStore.update(loadedBouquet.value.id, {
       ...data,
       tags: loadedBouquet.value.tags,
+      extras: { ...loadedBouquet.value.extras, ...extrasFromDatasets()},
     })
   }
   router.push({ name: "bouquet_detail", params: { bid: res.slug } })
 }
 
-const loadDatasets = async (datasetIds) => {
+const loadDatasets = async (datasetIds, bouquet) => {
   for (const datasetId of datasetIds) {
-    datasets.value.push(await datasetStore.load(datasetId))
+    const dataset = await datasetStore.load(datasetId)
+    datasets.value.push({
+      dataset,
+      description: bouquet.extras[`ecospheres:${dataset.id}:description`] || "",
+    })
   }
 }
 
@@ -74,7 +124,7 @@ onMounted(() => {
       loadedBouquet.value = data
       form.value.name = data.name
       form.value.description = data.description
-      loadDatasets(data.datasets.map(d => d.id))
+      loadDatasets(data.datasets.map(d => d.id), data)
     })
   }
 })
@@ -103,41 +153,75 @@ onMounted(() => {
         :is-textarea="true"
         :required="true"
       />
-      <label for="select-datasets">Jeux de données</label>
-      <Multiselect
-        noOptionsText="Précisez ou élargissez votre recherche"
-        ref="selector"
-        class="fr-mt-1w fr-mb-2w"
-        placeholder="Cherchez un jeu de données"
-        name="select-datasets"
-        v-model="selectedDataset"
-        :filter-results="false"
-        :min-chars="1"
-        :resolve-on-load="false"
-        :delay="0"
-        :searchable="true"
-        :options="search"
-        @select="onSelect"
-      />
+      <DsfrButton label="Ajouter un jeu de données"
+        @click.stop.prevent="isModalOpen = true"
+        ref="modalOrigin" :secondary="true" />
+      <DsfrModal
+        ref="modal"
+        :opened="isModalOpen"
+        title="Ajouter un jeu de données"
+        @close="isModalOpen = false"
+        :origin="$refs.modalOrigin"
+        :actions="modalActions"
+      >
+        <label for="select-datasets">Sélectionnez un jeu de données</label>
+        <Multiselect
+          noOptionsText="Précisez ou élargissez votre recherche"
+          ref="selector"
+          class="fr-mt-1w fr-mb-2w"
+          placeholder="Cherchez un jeu de données"
+          name="select-datasets"
+          v-model="selectedDataset.id"
+          :filter-results="false"
+          :min-chars="1"
+          :resolve-on-load="false"
+          :delay="0"
+          :searchable="true"
+          :options="search"
+          v-if="!isEditDesc"
+        />
+        <DsfrInput v-else
+          class="fr-mt-1w fr-mb-2w"
+          :disabled="true"
+          v-model="selectedDataset.title"
+        />
+        <DsfrInput
+          class="fr-mt-1w fr-mb-2w"
+          v-model="selectedDataset.description"
+          label="Description du jeu de données dans le bouquet"
+          placeholder="Pourquoi avez-vous ajouté ce jeu de données ?"
+          :label-visible="true"
+          :is-textarea="true"
+        />
+      </DsfrModal>
       <div class="fr-table">
         <table v-if="datasets.length">
           <thead>
             <tr>
               <th scope="col">Titre</th>
               <th scope="col">Organisation</th>
+              <th scope="col">Description</th>
               <th scope="col">Action</th>
             </tr>
           </thead>
           <tbody>
             <tr v-for="d in datasets">
-              <td>{{ d.title }}</td>
-              <td>{{ d.organization?.name }}</td>
+              <td>{{ d.dataset.title }}</td>
+              <td>{{ d.dataset.organization?.name }}</td>
+              <td>{{ d.description }}</td>
               <td>
-                <DsfrButton
-                  :icon-only="true" icon="ri-delete-bin-line"
-                  title="Supprimer"
-                  @click.stop.prevent="onDeleteDataset(d.id)"
-                />
+                <div class="es__button-container">
+                  <DsfrButton
+                    :icon-only="true" icon="ri-delete-bin-line" size="sm"
+                    title="Supprimer"
+                    @click.stop.prevent="onDeleteDataset(d.dataset.id)"
+                  />
+                  <DsfrButton
+                    :icon-only="true" icon="ri-pencil-line" size="sm"
+                    title="Editer"
+                    @click.stop.prevent="onEditDataset(d.dataset)"
+                  />
+                </div>
               </td>
             </tr>
           </tbody>
@@ -147,3 +231,12 @@ onMounted(() => {
     </form>
   </div>
 </template>
+
+<style scoped lang="scss">
+.es__button-container {
+  display: flex;
+  button:first-child {
+    margin-right: 0.5em;
+  }
+}
+</style>


### PR DESCRIPTION
A user description can be filled when adding a dataset to a bouquet. It can be edited later. It's also displayed on the bouquet detail view for each dataset.

NB: storage is done "flat" in the `extras`, using a specially formatted key for each dataset. It could be done via a nested list attribute `ecospheres: []` but it made the code more complex so I kept with flat.