### PR TITLE
Switch to data.gouv.fr search API by topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,3 @@ npm run build
 ```sh
 npm run lint
 ```
-
-### Setup search engine
-
-See https://github.com/ecolabdata/ecospheres-search-index

--- a/config.yaml
+++ b/config.yaml
@@ -3,6 +3,12 @@
 # data.gouv.fr base URL
 datagouvfr_base_url: https://demo.data.gouv.fr
 
+# "universe" topic id
+universe_topic_id: 65141cd780d73f98142e9265
+
+# universe name, used as bouquets tag
+universe_name: ecospheres
+
 # oauth settings
 datagouvfr_oauth_client_id: 651479c317ad47b21e41a9d4
 # pkce client secret, explicitely public

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "axios": "^1.4.0",
         "filesize": "^10.0.7",
         "marked": "^5.1.0",
-        "meilisearch": "^0.33.0",
         "pinia": "^2.1.4",
         "string-strip-html": "^13.4.3",
         "vue": "^3.3.4",
@@ -1015,14 +1014,6 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
-    "node_modules/cross-fetch": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.6.tgz",
-      "integrity": "sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==",
-      "dependencies": {
-        "node-fetch": "^2.6.11"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1825,14 +1816,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/meilisearch": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/meilisearch/-/meilisearch-0.33.0.tgz",
-      "integrity": "sha512-bYPb9WyITnJfzf92e7QFK8Rc50DmshFWxypXCs3ILlpNh8pT15A7KSu9Xgnnk/K3G/4vb3wkxxtFS4sxNkWB8w==",
-      "dependencies": {
-        "cross-fetch": "^3.1.6"
-      }
-    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -1892,25 +1875,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -2567,11 +2531,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -2748,20 +2707,6 @@
         "vue": {
           "optional": true
         }
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "axios": "^1.4.0",
     "filesize": "^10.0.7",
     "marked": "^5.1.0",
-    "meilisearch": "^0.33.0",
     "pinia": "^2.1.4",
     "string-strip-html": "^13.4.3",
     "vue": "^3.3.4",

--- a/src/services/api/SearchAPI.js
+++ b/src/services/api/SearchAPI.js
@@ -1,22 +1,24 @@
-import { MeiliSearch } from "meilisearch"
-import { useLoading } from 'vue-loading-overlay'
+import { useLoading } from "vue-loading-overlay"
 import { toast } from "vue3-toastify"
+import DatagouvfrAPI from "./DatagouvfrAPI"
+import config from "@/config"
 
 const $loading = useLoading()
 
 /**
  * A wrapper around search engine API
  */
-export default class SearchAPI {
-  constructor () {
-    const host = import.meta.env.VITE_SEARCH_ENGINE_URL
-    const apiKey = import.meta.env.VITE_SEARCH_ENGINE_PUBLIC_KEY
-    const client = new MeiliSearch({host, apiKey})
-    this.index = client.index("datasets")
-  }
+export default class SearchAPI extends DatagouvfrAPI{
+  version = "2"
+  endpoint = "datasets/search"
 
   _search(query, args) {
-    return this.index.search(query, args)
+    args = args || {}
+    args.topic = args.topic || config.universe_topic_id
+    args.q = query || ""
+    const qs = new URLSearchParams(args).toString()
+    const url = `${this.url()}/?${qs}`
+    return this.request(url)
   }
 
   search (query, args) {

--- a/src/store/BouquetStore.js
+++ b/src/store/BouquetStore.js
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia"
 import TopicsAPI from "../services/api/resources/TopicsAPI"
+import config from "@/config"
 
 const topicsAPI = new TopicsAPI()
 
@@ -15,7 +16,11 @@ export const useBouquetStore = defineStore("bouquet", {
      * @returns {Array}
      */
     filter (bouquets) {
-      return bouquets.filter(bouquet => bouquet.tags.includes("ecospheres"))
+      return bouquets.filter(bouquet => {
+        return bouquet.tags.includes(config.universe_name)
+          && bouquet.id !== config.universe_topic_id
+          && bouquet.slug !== config.universe_topic_id
+      })
     },
     /**
      * Load Ecospheres related bouquets from API

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -14,11 +14,12 @@ export const useSearchStore = defineStore("search", {
       return state.data.facetDistribution || {}
     },
     datasets: (state) => {
-      return state.data.hits || []
+      return state.data.data || []
     },
     pagination: (state) => {
-      if (!state.data) return []
-      return [...Array(state.data.totalPages).keys()].map(page => {
+      if (!state.data.total) return []
+      const totalPages = Math.ceil(state.data.total / pageSize)
+      return [...Array(totalPages).keys()].map(page => {
         page += 1
         return {
           label: page,
@@ -29,8 +30,8 @@ export const useSearchStore = defineStore("search", {
     },
   },
   actions: {
-    async search (query, page = 1, filter = []) {
-      const args = { hitsPerPage: pageSize, facets: ["organization.name"], page: page, filter: filter}
+    async search (query, page = 1) {
+      const args = { page_size: pageSize, page }
       const results = await searchAPI.search(query, args)
       this.data = results
     }

--- a/src/views/bouquets/BouquetDetailView.vue
+++ b/src/views/bouquets/BouquetDetailView.vue
@@ -6,6 +6,7 @@ import { useBouquetStore } from "../../store/BouquetStore"
 import { useDatasetStore } from "../../store/DatasetStore"
 import { useUserStore } from "../../store/UserStore"
 import { descriptionFromMarkdown } from "../../utils"
+import config from "@/config"
 import Tile from "../../components/Tile.vue"
 
 const route = useRoute()
@@ -47,7 +48,7 @@ onMounted(() => {
           :description="d.description"
           :img="d.organization.logo"
           :is-markdown="true"
-          :notice="bouquet.extras[`ecospheres:${d.id}:description`]"
+          :notice="bouquet.extras[`${config.universe_name}:${d.id}:description`]"
         />
       </li>
     </ul>

--- a/src/views/bouquets/BouquetEditView.vue
+++ b/src/views/bouquets/BouquetEditView.vue
@@ -5,6 +5,7 @@ import { useBouquetStore } from "../../store/BouquetStore"
 import { useRouter, useRoute } from "vue-router"
 import SearchAPI from "../../services/api/SearchAPI"
 import Multiselect from "@vueform/multiselect"
+import config from "@/config"
 
 const searchAPI = new SearchAPI()
 const datasetStore = useDatasetStore()
@@ -44,10 +45,10 @@ const modalActions = [
 
 const search = async (query) => {
   if (!query) return []
-  const results = await searchAPI._search(query, { hitsPerPage: 10 })
-  return results.hits.map(r => {
+  const results = await searchAPI._search(query, { page_size: 10 })
+  return results.data.map(r => {
     return { value: r.id, label: r.title }
-  }).filter(r => !datasets.value.map(d => d.id).includes(r.value))
+  }).filter(r => !datasets.value.map(d => d.dataset.id).includes(r.value))
 }
 
 const onSubmitModal = async () => {
@@ -67,7 +68,7 @@ const onSubmitModal = async () => {
 
 const onDeleteDataset = (datasetId) => {
   datasets.value = datasets.value.filter(d => d.dataset.id !== datasetId)
-  delete loadedBouquet.value.extras[`ecospheres:${datasetId}:description`]
+  delete loadedBouquet.value.extras[`${config.universe_name}:${datasetId}:description`]
 }
 
 const onEditDataset = (dataset) => {
@@ -81,7 +82,7 @@ const onEditDataset = (dataset) => {
 const extrasFromDatasets = () => {
   const extras = {}
   for (const dataset of datasets.value) {
-    extras[`ecospheres:${dataset.dataset.id}:description`] = dataset.description
+    extras[`${config.universe_name}:${dataset.dataset.id}:description`] = dataset.description
   }
   return extras
 }
@@ -95,7 +96,7 @@ const onSubmit = async () => {
   if (isCreate) {
     res = await bouquetStore.create({
       ...data,
-      tags: ["ecospheres"],
+      tags: [config.universe_name],
       extras: extrasFromDatasets(),
     })
   } else {
@@ -113,7 +114,7 @@ const loadDatasets = async (datasetIds, bouquet) => {
     const dataset = await datasetStore.load(datasetId)
     datasets.value.push({
       dataset,
-      description: bouquet.extras[`ecospheres:${dataset.id}:description`] || "",
+      description: bouquet.extras[`${config.universe_name}:${dataset.id}:description`] || "",
     })
   }
 }

--- a/src/views/datasets/DatasetsListView.vue
+++ b/src/views/datasets/DatasetsListView.vue
@@ -8,45 +8,17 @@ const route = useRoute()
 const store = useSearchStore()
 const query = computed(() => route.query.q)
 const currentPage = ref(1)
-const searchFilter = ref([])
-const selectedOrg = ref(null)
 
 const datasets = computed(() => store.datasets)
 const pages = computed(() => store.pagination)
 
-const orgFacets = computed(() => {
-  return Object.keys(store.facets["organization.name"] || {}).map(k => {
-    const count = store.facets["organization.name"][k]
-    return {
-      text: `${k} (${count})`,
-      value: k,
-    }
-  }).sort((a, b) => a.value - b.value)
-})
-
-const filterSearch = (filterKey, filterValue) => {
-  if (!filterValue) return
-  searchFilter.value = [`${filterKey} = "${filterValue}"`]
-}
-
-const onSelectOrg = (value) => {
-  selectedOrg.value = value
-  filterSearch("organization.name", value)
-}
-
-const resetFilter = () => {
-  searchFilter.value = []
-  selectedOrg.value = null
-}
-
 // reset currentPage when query changes
 onBeforeRouteUpdate((to, from) => {
   currentPage.value = 1
-  resetFilter()
 })
 
 watchEffect(() => {
-  store.search(query.value, currentPage.value, searchFilter.value)
+  store.search(query.value, currentPage.value)
 })
 </script>
 
@@ -55,29 +27,17 @@ watchEffect(() => {
     <h2 v-if="query">Résultats de recherche pour "{{ query }}"</h2>
     <h2 v-else>Jeux de données</h2>
     <div class="fr-mb-4w" v-if="query && datasets?.length === 0">Aucun résultat pour cette recherche.</div>
-    <div class="fr-grid-row">
-      <div class="fr-col-md-4 fr-pr-md-2w fr-mb-2w">
-        <div class="fr-mb-2w">
-          <a href="#" :click.prevent.stop="resetFilter" v-if="selectedOrg">x Effacer les filtres</a>
-        </div>
-        <DsfrSelect :options="orgFacets" :model-value="selectedOrg" @update:modelValue="onSelectOrg">
-          <template #label>Organisation</template>
-        </DsfrSelect>
-      </div>
-      <div class="fr-col-md-8">
-        <ul class="fr-grid-row fr-grid-row--gutters es__tiles__list">
-          <li v-for="d in datasets" class="fr-col-12 fr-col-lg-4">
-            <Tile
-              :link="`/datasets/${d.slug}`"
-              :title="d.title"
-              :description="d.description"
-              :img="d.organization.logo"
-              :is-markdown="true"
-            />
-          </li>
-        </ul>
-      </div>
-    </div>
+    <ul class="fr-grid-row fr-grid-row--gutters es__tiles__list">
+      <li v-for="d in datasets" class="fr-col-12 fr-col-lg-4">
+        <Tile
+          :link="`/datasets/${d.slug}`"
+          :title="d.title"
+          :description="d.description"
+          :img="d.organization.logo"
+          :is-markdown="true"
+        />
+      </li>
+    </ul>
   </div>
   <DsfrPagination v-if="pages.length" :current-page="currentPage - 1" :pages="pages" @update:current-page="p => currentPage = p + 1" />
 </template>


### PR DESCRIPTION
This switches to the data.gouv.fr's datasets search by topic. The topic is defined as `universe_topic_id`, ATM as a slug but very soon as a technical id (pending data.gouv.fr's deploy).

It removes the organization filter since faceting is not available anymore. We could build it again from the organizations list, but it's another story for another time :-)

This also introduces a `universe_name` variable used to tag bouquets and namespace bouquets extras, for the sake of a generic solution. 