### PR TITLE
Two-pass bouquet list using X-Fields

### DIFF
--- a/src/services/api/DatagouvfrAPI.js
+++ b/src/services/api/DatagouvfrAPI.js
@@ -11,9 +11,7 @@ const instance = axios.create()
 instance.interceptors.request.use(config => {
   const store = useUserStore()
   if (store.$state.isLoggedIn) {
-    config.headers = {
-      Authorization: `Bearer ${store.$state.token}`
-    }
+    config.headers.Authorization = `Bearer ${store.$state.token}`
   }
   return config
 }, error => Promise.reject(error))
@@ -45,6 +43,7 @@ export default class DatagouvfrAPI {
    * @returns
    */
   async request (url, method = "get", params = {}) {
+    // FIXME: instance[method] params differ depending on method
     const res = await instance[method](url, params)
     return res.data
   }
@@ -103,8 +102,8 @@ export default class DatagouvfrAPI {
    *
    * @returns {Promise}
    */
-  async _list () {
-    return await this.request(`${this.url()}/`)
+  async _list (headers = {}) {
+    return await this.request(`${this.url()}/`, "get", {"headers": headers})
   }
 
   /**


### PR DESCRIPTION
WIP to optimize loading bouquets until https://github.com/ecolabdata/ecospheres-front/issues/51 is fixed.

I could not test with the 85K datasets from our org list because I can't feed them to the topic 😢 With 1.5K datasets the PR is _slower_ than what we currently have: 12s vs 9s. We'll have to wait for way to push more datasets to see if performance is favorable with extra large topics.

Also, I might have done a bad job at implementing the two-pass heuristic 😅 