### PR TITLE
Filter topic by universe tag

### DIFF
--- a/src/services/api/DatagouvfrAPI.js
+++ b/src/services/api/DatagouvfrAPI.js
@@ -107,10 +107,15 @@ export default class DatagouvfrAPI {
   /**
    * List entities, without wrapper
    *
+   * @param {object?} filter
    * @returns {Promise}
    */
-  async _list() {
-    return await this.request(`${this.url()}/`)
+  async _list(filter) {
+    const url = new URL(`${this.url()}/`);
+    if (filter) {
+      url.search = new URLSearchParams(filter)
+    }
+    return await this.request(url)
   }
 
   /**

--- a/src/services/api/DatagouvfrAPI.js
+++ b/src/services/api/DatagouvfrAPI.js
@@ -98,20 +98,25 @@ export default class DatagouvfrAPI {
   /**
    * List entities
    *
+   * @param {object} filter Optional filter argument, e.g. { tag: 'my_topic' }
    * @returns {Promise}
    */
-  async list() {
-    return await this.makeRequestAndHandleResponse(`${this.url()}/`)
+  async list(filter) {
+    const url = new URL(`${this.url()}/`)
+    if (filter) {
+      url.search = new URLSearchParams(filter)
+    }
+    return await this.makeRequestAndHandleResponse(url)
   }
 
   /**
    * List entities, without wrapper
    *
-   * @param {object?} filter
+   * @param {object} filter Optional filter argument, e.g. { tag: 'my_topic' }
    * @returns {Promise}
    */
   async _list(filter) {
-    const url = new URL(`${this.url()}/`);
+    const url = new URL(`${this.url()}/`)
     if (filter) {
       url.search = new URLSearchParams(filter)
     }

--- a/src/store/TopicStore.js
+++ b/src/store/TopicStore.js
@@ -31,10 +31,7 @@ export const useTopicStore = defineStore('topic', {
      */
     filter(topics) {
       return topics.filter((topic) => {
-        return (
-          topic.tags.includes(config.universe.name) &&
-          topic.id !== config.universe.topic_id
-        )
+        return topic.id !== config.universe.topic_id
       })
     },
     /**
@@ -44,7 +41,7 @@ export const useTopicStore = defineStore('topic', {
      */
     async loadTopicsForUniverse() {
       if (this.data.length > 0) return this.data
-      let response = await topicsAPI._list()
+      let response = await topicsAPI._list({tag: config.universe.name})
       this.data = this.filter(response.data)
       while (response.next_page) {
         response = await topicsAPI.request(response.next_page)

--- a/src/store/TopicStore.js
+++ b/src/store/TopicStore.js
@@ -41,7 +41,7 @@ export const useTopicStore = defineStore('topic', {
      */
     async loadTopicsForUniverse() {
       if (this.data.length > 0) return this.data
-      let response = await topicsAPI._list({tag: config.universe.name})
+      let response = await topicsAPI._list({ tag: config.universe.name })
       this.data = this.filter(response.data)
       while (response.next_page) {
         response = await topicsAPI.request(response.next_page)


### PR DESCRIPTION
Migre le filtre des topics par "univers" en amont au niveau de l'API, basé sur https://github.com/ecolabdata/ecospheres-front/issues/51.

Le temps de load de la page Bouquets passe de ~9s à ~4s chez moi.

On pourrait encore gratter un peu en augmentant le `page_size` mais ça me semble pas clean de le hard-coder dans l'appel à `_list()`. 

Il y a peut-être plus clean, je laisse les experts JS s'exprimer là-dessus...
Et dans tous les cas il faudra faire la même modif sur `list()`.
N'hésitez pas à adopter la PR :)