### PR TITLE
rfc: POC pour diviser le composant EditBouquet

### DIFF
--- a/src/components/forms/dataset/DatasetForTopicForm.vue
+++ b/src/components/forms/dataset/DatasetForTopicForm.vue
@@ -1,0 +1,68 @@
+<template>
+  <div class="app">
+    <form @submit.prevent="handleSubmit" class="checkout-form">
+      <h2>Ajout d'un dataset</h2>
+
+      <div class="fr-mt-1w fr-mb-4w">
+        <label class="fr-label" for="label">Libellé de la donnée</label>
+        <input class="fr-input" type="text" id="label" v-model="datasetItem.label">
+      </div>
+      <div>
+        <Tooltip
+          title="Raison d'utilisation dans ce bouquet"
+          name="tooltip__objectif"
+          text="Ajoutez ici l'ensemble des informations nécessaires à la compréhension, l'objectif et l'utilisation du bouquet. N'hésitez pas à indiquer la réglementation ou une documentation liée au bouquet."
+        />
+        <Tooltip
+          title="Utilisez du markdown pour mettre en forme votre texte"
+          name="tooltip__markdown"
+          text="* simple astérisque pour italique *<br/> ** double astérisque pour gras **<br/> # un dièse pour titre 1<br/> ## deux dièses pour titre 2<br/> *  astérisque pour une liste<br/> lien : [[https://exemple.fr]]"
+        />
+        <textarea class="fr-input" type="text" id="purpose" v-model="datasetItem.purpose"/>
+      </div>
+
+      <DsfrButton
+        type="submit"
+        label="Ajouter la donnée"
+        :secondary="true"
+      />
+
+    </form>
+  </div>
+</template>
+
+<script lang="ts">
+import Tooltip from '../../../components/Tooltip.vue'
+import type { DatasetItem } from '../../../model';
+
+interface DatasetForTopicFormData {
+  datasetItem: DatasetItem
+}
+
+export default {
+  name: "DatasetForTopicForm",
+  components: {
+    Tooltip: Tooltip
+  },
+  data(): DatasetForTopicFormData {
+    return {
+      datasetItem: {
+        label: '',
+        purpose: ''
+      }
+    }
+  },
+  methods: {
+    handleSubmit() {
+      this.$emit('addDataset', {
+        label: this.datasetItem.label,
+        purpose: this.datasetItem.purpose
+      })
+      this.datasetItem = {
+        label: '',
+        purpose: ''
+      }
+    }
+  }
+}
+</script>

--- a/src/components/forms/topic/TopicContentFieldGroup.vue
+++ b/src/components/forms/topic/TopicContentFieldGroup.vue
@@ -1,0 +1,45 @@
+<template>
+  <section class="topicProperties">
+    <div class="fr-grid-row">
+        <div class="fr-col-12 fr-col-lg-7">
+          <div>
+            <div class="fr-mt-1w">
+              <h2>Données déjà sélectionnées</h2>
+              {{ this.datasets }}
+              <DatasetForTopicForm @addDataset="addDataset"/>
+            </div>
+          </div>
+        </div>
+      </div>
+  </section>
+</template>
+
+<script lang="ts"> 
+  import DatasetForTopicForm from '../dataset/DatasetForTopicForm.vue';
+  import { DatasetItem } from '../../../model';
+
+  export default {
+    name: "TopicContentFieldGroup",
+    components: {
+      DatasetForTopicForm: DatasetForTopicForm,
+    },
+    props: {
+      currentDatasets: {
+        type: Array<DatasetItem>,
+        default: [],
+      },
+    },
+    data() {
+      return {
+        datasets: this.currentDatasets 
+      }
+    },
+    methods: {
+      addDataset(datasetItem: DatasetItem) {
+        this.datasets.push(datasetItem)
+        console.log(this.datasets[0])
+        this.$emit('update:datasets', this.datasets)
+      }
+    }
+  };
+</script>

--- a/src/components/forms/topic/TopicForm.vue
+++ b/src/components/forms/topic/TopicForm.vue
@@ -7,6 +7,10 @@
             v-model:topicName="name"
             v-model:topicDescription="description"
         />
+        <h1>Step 3 : Contenu </h1>
+        <TopicContentFieldGroup 
+          v-model:current-datasets="datasets"
+        />         
         <DsfrButton
           type="submit"
           label="Ajouter le bouquet"
@@ -18,11 +22,16 @@
   
 <script lang="ts">
   import TopicPropertiesFieldGroup from "./TopicPropertiesFieldGroup.vue";
+  import TopicContentFieldGroup from "./TopicContentFieldGroup.vue";
+  import TopicFormRecap from "./TopicFormRecap.vue";
+  import type { DatasetItem } from "../../../model";
   
   export default {
     name: "TopicForm",
     components: {
       TopicPropertiesFieldGroup: TopicPropertiesFieldGroup,
+      TopicContentFieldGroup: TopicContentFieldGroup,
+      TopicFormRecap: TopicFormRecap,
     },
     methods: {
       handleSubmit() {
@@ -39,11 +48,16 @@
         type: String,
         default: ''
       },
+      currentDatasets: {
+        type: Array<DatasetItem>,
+        default: [],
+      },
     },
     data() {
       return {
         name: this.currentName,
         description: this.currentDescription,
+        datasets: this.currentDatasets
       }
     },
   };

--- a/src/components/forms/topic/TopicForm.vue
+++ b/src/components/forms/topic/TopicForm.vue
@@ -7,10 +7,19 @@
             v-model:topicName="name"
             v-model:topicDescription="description"
         />
+
         <h1>Step 3 : Contenu </h1>
         <TopicContentFieldGroup 
           v-model:current-datasets="datasets"
         />         
+
+        <h1>Step 4 : Recap </h1>
+        <TopicFormRecap
+          :name="name"
+          :description="description"
+          :datasets="datasets"
+        />
+        
         <DsfrButton
           type="submit"
           label="Ajouter le bouquet"

--- a/src/components/forms/topic/TopicForm.vue
+++ b/src/components/forms/topic/TopicForm.vue
@@ -1,0 +1,50 @@
+<template>
+    <div class="app">
+      <form @submit.prevent="handleSubmit" class="checkout-form">
+        
+        <h1>Step 1 : Propriété </h1>
+        <TopicPropertiesFieldGroup 
+            v-model:topicName="name"
+            v-model:topicDescription="description"
+        />
+        <DsfrButton
+          type="submit"
+          label="Ajouter le bouquet"
+        />
+        
+      </form>
+    </div>
+  </template>
+  
+<script lang="ts">
+  import TopicPropertiesFieldGroup from "./TopicPropertiesFieldGroup.vue";
+  
+  export default {
+    name: "TopicForm",
+    components: {
+      TopicPropertiesFieldGroup: TopicPropertiesFieldGroup,
+    },
+    methods: {
+      handleSubmit() {
+        console.log("formDatasets :" + this.datasets)
+        alert("form submitted : " + this.name + " " + this.description);
+      },
+    },
+    props: {
+      currentName: {
+        type: String,
+        default: ''
+      },
+      currentDescription: {
+        type: String,
+        default: ''
+      },
+    },
+    data() {
+      return {
+        name: this.currentName,
+        description: this.currentDescription,
+      }
+    },
+  };
+</script>

--- a/src/components/forms/topic/TopicFormRecap.vue
+++ b/src/components/forms/topic/TopicFormRecap.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="app">
+    <h3>Bouquet : {{ this.name }}</h3>
+    description : {{ this.description }}
+    <p>contenu : </p> 
+    <ul>
+      <li v-for="dataset in datasets">
+        {{ dataset.label }} - {{ dataset.purpose }}
+      </li>
+    </ul>
+  </div>
+</template>
+  
+<script lang="ts">
+  import TopicPropertiesFieldGroup from "./TopicPropertiesFieldGroup.vue";
+  import TopicContentFieldGroup from "./TopicContentFieldGroup.vue";
+  import type {DatasetItem} from "../../../model"
+  
+  export default {
+    name: "TopicForm",
+    components: {
+        TopicPropertiesFieldGroup: TopicPropertiesFieldGroup,
+        TopicContentFieldGroup: TopicContentFieldGroup
+    },
+    props: {
+      name: {
+        type: String,
+        default: ''
+      },
+      description: {
+        type: String,
+        default: ''
+      },
+      datasets: {
+        type: Array<DatasetItem>,
+        default: [],
+      },
+    }
+  };
+</script>

--- a/src/components/forms/topic/TopicPropertiesFieldGroup.vue
+++ b/src/components/forms/topic/TopicPropertiesFieldGroup.vue
@@ -1,0 +1,56 @@
+<template>
+  <section class="topicProperties">
+    <div class="fr-grid-row">
+        <div class="fr-col-12 fr-col-lg-7">
+          <div>
+            <div class="fr-mt-1w fr-mb-4w">
+              <label class="fr-label" for="topic_name">Sujet du bouquet</label>
+              <input 
+                class="fr-input" type="text" id="topic_name" 
+                :value="topicName"
+                @input="$emit('update:topicName', $event.target.value)"
+              >
+            </div>
+            <div class="fr-mt-1w">
+              <Tooltip
+                title="Objectif du bouquet"
+                name="tooltip__objectif"
+                text="Ajoutez ici l'ensemble des informations nécessaires à la compréhension, l'objectif et l'utilisation du bouquet. N'hésitez pas à indiquer la réglementation ou une documentation liée au bouquet."
+              />
+              <Tooltip
+                title="Utilisez du markdown pour mettre en forme votre texte"
+                name="tooltip__markdown"
+                text="* simple astérisque pour italique *<br/> ** double astérisque pour gras **<br/> # un dièse pour titre 1<br/> ## deux dièses pour titre 2<br/> *  astérisque pour une liste<br/> lien : [[https://exemple.fr]]"
+              />
+              <textarea 
+                class="fr-input" type="text" id="topic_description" 
+                :value="topicDescription"
+                @input="$emit('update:topicDescription', $event.target.value)"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+  </section>
+</template>
+
+<script> 
+  import Tooltip from '@/components/Tooltip.vue'
+
+  export default {
+    name: "TopicPropertiesFieldGroup",
+    components: {
+        Tooltip: Tooltip
+    },
+    props: {
+      topicName: {
+        type: String,
+        default: "",
+      },
+      topicDescription: {
+        type: String,
+        default: "",
+      }
+    },
+  };
+</script>

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,0 +1,6 @@
+interface DatasetItem {
+    label: string,
+    purpose: string
+}
+
+export type { DatasetItem }

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -8,6 +8,7 @@ import config from '@/config'
 import HomeButtons from '../components/HomeButtons.vue'
 import HomeCharts from '../components/HomeCharts.vue'
 import HomeTopics from '../components/HomeTopics.vue'
+import TopicForm from '@/components/forms/topic/TopicForm.vue'
 
 const router = useRouter()
 const query = ref('')
@@ -32,6 +33,7 @@ const showTopicChart = config.website.show_topic_charts
 <template>
   <div class="fr-container fr-mt-8w fr-mb-16w">
     <h1>{{ homepageTitle }}</h1>
+    <TopicForm/>
     <div class="es__hero fr-mt-4w fr-mb-4w">
       <span v-html="markdown.render(homepageSubTitle)" />
     </div>


### PR DESCRIPTION
## RFC

Depends on #162 
Related to issue https://github.com/ecolabdata/ecospheres-front/issues/144

### Context or situation

Le composant editBouquet devient trop gros pour être gérable sur le moyen terme.

### Problem encountered by users

Invisible pour l'usager, mais pénible pour les dévs.

### Proposal of how to solve the problem

Décomposer en plusieurs composants et sous-composants tout en gardant l'accès aux informations.

### What changes

Dans la page d'acceuil s'affiche une version brute du formulaire de création/édition de bouquet. 

En éditant les premiers champs, les informations sont automatiquement retranscrite dans l'étape 4 récapitulative.

En cliquant sur ajouter la donnée dans l'étape 3 : 
  - un nouveau dataset est ajouté dans la section "Données déjà sélectionnées" de l'étape 3. 
  - le dataset est aussi automatiquement reporté dans l'étape 4 récapitulative

#### Breaking changes

La preuve de concept est sommairement affichée dans la page d'acceuil

#### Technical changes

- Preuve de concept pour juger de la complexité du chantier.
- Découpage en plusieurs composant, prise en compte de cas particulier étape 3 (composant contenant lui même un formulaire)
- Utilisation de typescript dans les sous-composants. Pas d'impact sur le reste du code et permets de garantir le format des données afin de prévenir un comportement imprévu à l'utilisation