### PR TITLE
Topic api v2

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -52,8 +52,9 @@ website:
   show_topic_charts: false
   list_highlighted_topics:
   oauth_option: true
-  # display settings
-  organizations_list_page_size: 9
+  pagination_sizes:
+    organizations_list: 9
+    topics_list: 100
   contact_email: ecospheres@developpement-durable.gouv.fr
 
 # For step 2 of bouquet creation

--- a/configs/meteo-france/config.yaml
+++ b/configs/meteo-france/config.yaml
@@ -61,7 +61,9 @@ website:
       name: 'Changement climatique'
   oauth_option: false
   # display settings
-  organizations_list_page_size: 9
+  pagination_sizes:
+    organizations_list: 9
+    topics_list: 100
 
 # list of organisations' ids that should be handled by the portal
 # to find an id go to https://www.data.gouv.fr/fr/organizations/ministere-de-la-transition-ecologique/

--- a/configs/sante-publique-france/config.yaml
+++ b/configs/sante-publique-france/config.yaml
@@ -62,7 +62,9 @@ website:
       name: 'Les données bactéries émergentes'
   oauth_option: false
   # display settings
-  organizations_list_page_size: 9
+  pagination_sizes:
+    organizations_list: 9
+    topics_list: 100
 
 # list of organisations' ids that should be handled by the portal
 # to find an id go to https://www.data.gouv.fr/fr/organizations/ministere-de-la-transition-ecologique/

--- a/src/services/api/DatagouvfrAPI.js
+++ b/src/services/api/DatagouvfrAPI.js
@@ -116,8 +116,8 @@ export default class DatagouvfrAPI {
    * @param {object} [params]
    * @returns {Promise}
    */
-  async list(params = {}) {
-    const qs = new URLSearchParams(params).toString()
+  async list(queryParams = {}) {
+    const qs = new URLSearchParams(queryParams).toString()
     return await this.makeRequestAndHandleResponse(`${this.url()}/?${qs}`)
   }
 
@@ -127,8 +127,8 @@ export default class DatagouvfrAPI {
    * @param {object} [params]
    * @returns {Promise}
    */
-  async _list(params = {}) {
-    const qs = new URLSearchParams(params).toString()
+  async _list(queryParams = {}) {
+    const qs = new URLSearchParams(queryParams).toString()
     return await this.request(`${this.url()}/?${qs}`)
   }
 

--- a/src/services/api/DatagouvfrAPI.js
+++ b/src/services/api/DatagouvfrAPI.js
@@ -38,11 +38,11 @@ export default class DatagouvfrAPI {
   endpoint = ''
   httpClient = instance
 
-  constructor(baseUrl, version, endpoint, httpClient) {
-    this.base_url = baseUrl || this.base_url
-    this.version = version || this.version
-    this.endpoint = endpoint || this.endpoint
-    this.httpClient = httpClient || this.httpClient
+  constructor(params) {
+    this.base_url = params?.baseUrl || this.base_url
+    this.version = params?.version || this.version
+    this.endpoint = params?.endpoint || this.endpoint
+    this.httpClient = params?.httpClient || this.httpClient
   }
 
   url() {

--- a/src/services/api/DatagouvfrAPI.js
+++ b/src/services/api/DatagouvfrAPI.js
@@ -33,7 +33,7 @@ instance.interceptors.request.use(
  * e.g. OrganizationsAPI will declare `endpoint = organizations`.
  */
 export default class DatagouvfrAPI {
-  baseUrl = `${config.datagouvfr.baseUrl}/api`
+  baseUrl = `${config.datagouvfr.base_url}/api`
   version = '1'
   endpoint = ''
   httpClient = instance

--- a/src/services/api/DatagouvfrAPI.js
+++ b/src/services/api/DatagouvfrAPI.js
@@ -108,7 +108,7 @@ export default class DatagouvfrAPI {
   /**
    * List entities
    *
-   * @param {object} [params]
+   * @param {object} [queryParams]
    * @returns {Promise}
    */
   async list(queryParams = {}) {
@@ -119,7 +119,7 @@ export default class DatagouvfrAPI {
   /**
    * List entities, without wrapper
    *
-   * @param {object} [params]
+   * @param {object} [queryParams]
    * @returns {Promise}
    */
   async _list(queryParams = {}) {

--- a/src/services/api/DatagouvfrAPI.js
+++ b/src/services/api/DatagouvfrAPI.js
@@ -33,7 +33,7 @@ instance.interceptors.request.use(
  * e.g. OrganizationsAPI will declare `endpoint = organizations`.
  */
 export default class DatagouvfrAPI {
-  base_url = `${config.datagouvfr.base_url}/api`
+  baseUrl = `${config.datagouvfr.baseUrl}/api`
   version = '1'
   endpoint = ''
   httpClient = instance
@@ -47,7 +47,7 @@ export default class DatagouvfrAPI {
   }
 
   url() {
-    return `${this.base_url}/${this.version}/${this.endpoint}`
+    return `${this.baseUrl}/${this.version}/${this.endpoint}`
   }
 
   /**

--- a/src/services/api/DatagouvfrAPI.js
+++ b/src/services/api/DatagouvfrAPI.js
@@ -38,7 +38,13 @@ export default class DatagouvfrAPI {
   endpoint = ''
   httpClient = instance
 
-  constructor(params) {
+    constructor(args = {}) {
+        const { baseUrl, version, endpoint, httpClient } = args
+        this.baseUrl = baseUrl ?? this.baseUrl;
+        this.version = version ?? this.version;
+        this.endpoint = endpoint ?? this.endpoint;
+        this.httpClient = httpClient ?? this.httpClient;
+    }
     this.base_url = params?.baseUrl || this.base_url
     this.version = params?.version || this.version
     this.endpoint = params?.endpoint || this.endpoint

--- a/src/services/api/DatagouvfrAPI.js
+++ b/src/services/api/DatagouvfrAPI.js
@@ -38,17 +38,12 @@ export default class DatagouvfrAPI {
   endpoint = ''
   httpClient = instance
 
-    constructor(args = {}) {
-        const { baseUrl, version, endpoint, httpClient } = args
-        this.baseUrl = baseUrl ?? this.baseUrl;
-        this.version = version ?? this.version;
-        this.endpoint = endpoint ?? this.endpoint;
-        this.httpClient = httpClient ?? this.httpClient;
-    }
-    this.base_url = params?.baseUrl || this.base_url
-    this.version = params?.version || this.version
-    this.endpoint = params?.endpoint || this.endpoint
-    this.httpClient = params?.httpClient || this.httpClient
+  constructor(args = {}) {
+    const { baseUrl, version, endpoint, httpClient } = args
+    this.baseUrl = baseUrl || this.baseUrl
+    this.version = version || this.version
+    this.endpoint = endpoint || this.endpoint
+    this.httpClient = httpClient || this.httpClient
   }
 
   url() {

--- a/src/services/api/DatagouvfrAPI.js
+++ b/src/services/api/DatagouvfrAPI.js
@@ -107,19 +107,23 @@ export default class DatagouvfrAPI {
   /**
    * List entities
    *
+   * @param {object} [params]
    * @returns {Promise}
    */
-  async list() {
-    return await this.makeRequestAndHandleResponse(`${this.url()}/`)
+  async list(params = {}) {
+    const qs = new URLSearchParams(params).toString()
+    return await this.makeRequestAndHandleResponse(`${this.url()}/?${qs}`)
   }
 
   /**
    * List entities, without wrapper
    *
+   * @param {object} [params]
    * @returns {Promise}
    */
-  async _list() {
-    return await this.request(`${this.url()}/`)
+  async _list(params = {}) {
+    const qs = new URLSearchParams(params).toString()
+    return await this.request(`${this.url()}/?${qs}`)
   }
 
   /**

--- a/src/services/api/__tests__/DatagouvfrAPI.test.js
+++ b/src/services/api/__tests__/DatagouvfrAPI.test.js
@@ -44,7 +44,12 @@ beforeEach(async (context) => {
   setActivePinia(createPinia())
   const httpClient = axios.create()
   httpClient.defaults.proxy = false
-  context.client = new DatagouvfrAPI(baseUrl, version, endpoint, httpClient)
+  context.client = new DatagouvfrAPI({
+    baseUrl,
+    version,
+    endpoint,
+    httpClient
+  })
 })
 
 afterEach(() => {

--- a/src/services/api/__tests__/DatagouvfrAPI.test.js
+++ b/src/services/api/__tests__/DatagouvfrAPI.test.js
@@ -32,6 +32,10 @@ const server = setupServer(
 
   http.delete(`${baseUrl}/${version}/${endpoint}/${networkError}/`, () => {
     return HttpResponse.error()
+  }),
+
+  http.get(`${baseUrl}/${version}/${endpoint}/`, () => {
+    return HttpResponse.json([], { status: 200 })
   })
 )
 
@@ -73,4 +77,9 @@ test('delete when 404', async ({ client }) => {
 test('delete something else', async ({ client }) => {
   const { message } = await client.delete(networkError)
   expect(message).toMatch(/network error/i)
+})
+
+test('raw list', async ({ client }) => {
+  const res = await client._list()
+  expect(Array.isArray(res)).toBeTruthy()
 })

--- a/src/services/api/__tests__/DatagouvfrAPI.test.js
+++ b/src/services/api/__tests__/DatagouvfrAPI.test.js
@@ -20,6 +20,7 @@ const endpoint = 'asdf'
 const noContent = uuid()
 const notFound = uuid()
 const networkError = uuid()
+const entityId = uuid()
 
 const server = setupServer(
   http.delete(`${baseUrl}/${version}/${endpoint}/${noContent}/`, () => {
@@ -36,6 +37,10 @@ const server = setupServer(
 
   http.get(`${baseUrl}/${version}/${endpoint}/`, () => {
     return HttpResponse.json([], { status: 200 })
+  }),
+
+  http.get(`${baseUrl}/${version}/${endpoint}/${entityId}/`, () => {
+    return HttpResponse.json({ id: entityId }, { status: 200 })
   })
 )
 
@@ -82,4 +87,9 @@ test('delete something else', async ({ client }) => {
 test('raw list', async ({ client }) => {
   const res = await client._list()
   expect(Array.isArray(res)).toBeTruthy()
+})
+
+test('raw get', async ({ client }) => {
+  const res = await client._get(entityId)
+  expect(res.id).toEqual(entityId)
 })

--- a/src/services/api/resources/TopicsAPI.js
+++ b/src/services/api/resources/TopicsAPI.js
@@ -2,5 +2,4 @@ import DatagouvfrAPI from '../DatagouvfrAPI'
 
 export default class TopicsAPI extends DatagouvfrAPI {
   endpoint = 'topics'
-  version = 2
 }

--- a/src/services/api/resources/TopicsAPI.js
+++ b/src/services/api/resources/TopicsAPI.js
@@ -2,4 +2,5 @@ import DatagouvfrAPI from '../DatagouvfrAPI'
 
 export default class TopicsAPI extends DatagouvfrAPI {
   endpoint = 'topics'
+  version = 2
 }

--- a/src/store/DatasetStore.js
+++ b/src/store/DatasetStore.js
@@ -132,7 +132,7 @@ export const useDatasetStore = defineStore('dataset', {
     /**
      * Load multiple datasets from API via a HATEOAS rel
      *
-     * @param {Object} rel - HATEOS rel for datasets
+     * @param {Object} rel - HATEOAS rel for datasets
      * @returns {Array<object>}
      */
     async loadMultiple(rel) {
@@ -147,10 +147,10 @@ export const useDatasetStore = defineStore('dataset', {
       return datasets
     },
     /**
-     * Load resources from the API via a HATEOS rel
+     * Load resources from the API via a HATEOAS rel
      *
      * @param {String} dataset_id
-     * @param {Object} rel - HATEOS rel for datasets
+     * @param {Object} rel - HATEOAS rel for datasets
      * @returns {Array<object>}
      */
     async loadResources(rel) {

--- a/src/store/OrganizationStore.js
+++ b/src/store/OrganizationStore.js
@@ -24,7 +24,7 @@ export const useOrganizationStore = defineStore('organization', {
      * @returns {Array<object>}
      */
     getPagination() {
-      const pageSize = config.website.organizations_list_page_size
+      const pageSize = config.website.pagination_sizes.organizations_list
       const total = config.organizations.length
       const nbPages = Math.ceil(total / pageSize)
       return [...Array(nbPages).keys()].map((page) => {
@@ -53,7 +53,7 @@ export const useOrganizationStore = defineStore('organization', {
      * @returns {Array<object>}
      */
     async loadFromConfig(page = 1) {
-      const pageSize = config.website.organizations_list_page_size
+      const pageSize = config.website.pagination_sizes.organizations_list
       const paginated = config.organizations.slice(
         pageSize * (page - 1),
         pageSize * page

--- a/src/store/TopicStore.js
+++ b/src/store/TopicStore.js
@@ -30,12 +30,7 @@ export const useTopicStore = defineStore('topic', {
      * @returns {Array}
      */
     filter(topics) {
-      return topics.filter((topic) => {
-        return (
-          topic.tags.includes(config.universe.name) &&
-          topic.id !== config.universe.topic_id
-        )
-      })
+      return topics.filter((topic) => topic.id !== config.universe.topic_id)
     },
     /**
      * Load universe related topics from API
@@ -44,7 +39,7 @@ export const useTopicStore = defineStore('topic', {
      */
     async loadTopicsForUniverse() {
       if (this.data.length > 0) return this.data
-      let response = await topicsAPI._list()
+      let response = await topicsAPI._list({ page_size: 100, tag: config.universe.name })
       this.data = this.filter(response.data)
       while (response.next_page) {
         response = await topicsAPI.request(response.next_page)

--- a/src/store/TopicStore.js
+++ b/src/store/TopicStore.js
@@ -40,7 +40,10 @@ export const useTopicStore = defineStore('topic', {
      */
     async loadTopicsForUniverse() {
       if (this.data.length > 0) return this.data
-      let response = await topicsAPIv2._list({ page_size: 100, tag: config.universe.name })
+      let response = await topicsAPIv2._list({
+        page_size: 100,
+        tag: config.universe.name
+      })
       this.data = this.filter(response.data)
       while (response.next_page) {
         response = await topicsAPIv2.request(response.next_page)

--- a/src/store/TopicStore.js
+++ b/src/store/TopicStore.js
@@ -41,7 +41,7 @@ export const useTopicStore = defineStore('topic', {
     async loadTopicsForUniverse() {
       if (this.data.length > 0) return this.data
       let response = await topicsAPIv2._list({
-        page_size: 100,
+        page_size: config.website.pagination_sizes.topics_list,
         tag: config.universe.name
       })
       this.data = this.filter(response.data)

--- a/src/store/TopicStore.js
+++ b/src/store/TopicStore.js
@@ -5,6 +5,7 @@ import config from '@/config'
 import TopicsAPI from '../services/api/resources/TopicsAPI'
 
 const topicsAPI = new TopicsAPI()
+const topicsAPIv2 = new TopicsAPI({ version: 2 })
 
 export const useTopicStore = defineStore('topic', {
   state: () => ({
@@ -39,10 +40,10 @@ export const useTopicStore = defineStore('topic', {
      */
     async loadTopicsForUniverse() {
       if (this.data.length > 0) return this.data
-      let response = await topicsAPI._list({ page_size: 100, tag: config.universe.name })
+      let response = await topicsAPIv2._list({ page_size: 100, tag: config.universe.name })
       this.data = this.filter(response.data)
       while (response.next_page) {
-        response = await topicsAPI.request(response.next_page)
+        response = await topicsAPIv2.request(response.next_page)
         this.data = [...this.data, ...this.filter(response.data)]
       }
       return this.data
@@ -65,7 +66,7 @@ export const useTopicStore = defineStore('topic', {
     async load(slugOrId) {
       const existing = this.get(slugOrId)
       if (existing) return existing
-      return await topicsAPI.get(slugOrId)
+      return await topicsAPIv2._get(slugOrId)
     },
     /**
      * Create a topic

--- a/src/views/bouquets/BouquetDetailView.vue
+++ b/src/views/bouquets/BouquetDetailView.vue
@@ -8,6 +8,7 @@ import { useDatasetStore } from '../../store/DatasetStore'
 import { useTopicStore } from '../../store/TopicStore'
 import { useUserStore } from '../../store/UserStore'
 import { descriptionFromMarkdown } from '../../utils'
+import { useLoading } from 'vue-loading-overlay'
 
 const route = useRoute()
 const router = useRouter()
@@ -16,6 +17,7 @@ const userStore = useUserStore()
 const datasetStore = useDatasetStore()
 const bouquet = ref({})
 const datasets = ref([])
+const loading = useLoading()
 
 const description = computed(() => descriptionFromMarkdown(bouquet))
 
@@ -32,11 +34,15 @@ const canCreate = computed(() => {
 })
 
 onMounted(() => {
+  const loader = loading.show()
   store.load(route.params.bid).then((res) => {
     bouquet.value = res
     datasetStore
-      .loadMultiple(bouquet.value.datasets.map((d) => d.id))
-      .then((ds) => (datasets.value = ds))
+      .loadMultiple(res.datasets)
+      .then((ds) => {
+        datasets.value = ds
+        loader.hide()
+      })
   })
 })
 </script>

--- a/src/views/bouquets/BouquetDetailView.vue
+++ b/src/views/bouquets/BouquetDetailView.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { onMounted, ref, computed } from 'vue'
+import { useLoading } from 'vue-loading-overlay'
 import { useRoute, useRouter } from 'vue-router'
 
 import config from '@/config'
@@ -8,7 +9,6 @@ import { useDatasetStore } from '../../store/DatasetStore'
 import { useTopicStore } from '../../store/TopicStore'
 import { useUserStore } from '../../store/UserStore'
 import { descriptionFromMarkdown } from '../../utils'
-import { useLoading } from 'vue-loading-overlay'
 
 const route = useRoute()
 const router = useRouter()
@@ -37,12 +37,10 @@ onMounted(() => {
   const loader = loading.show()
   store.load(route.params.bid).then((res) => {
     bouquet.value = res
-    datasetStore
-      .loadMultiple(res.datasets)
-      .then((ds) => {
-        datasets.value = ds
-        loader.hide()
-      })
+    datasetStore.loadMultiple(res.datasets).then((ds) => {
+      datasets.value = ds
+      loader.hide()
+    })
   })
 })
 </script>

--- a/src/views/bouquets/BouquetDetailView.vue
+++ b/src/views/bouquets/BouquetDetailView.vue
@@ -35,13 +35,16 @@ const canCreate = computed(() => {
 
 onMounted(() => {
   const loader = loading.show()
-  store.load(route.params.bid).then((res) => {
-    bouquet.value = res
-    datasetStore.loadMultiple(res.datasets).then((ds) => {
-      datasets.value = ds
-      loader.hide()
+  store
+    .load(route.params.bid)
+    .then((res) => {
+      bouquet.value = res
+      // FIXME: not used anymore in template below, change template or remove
+      return datasetStore.loadMultiple(res.datasets).then((ds) => {
+        datasets.value = ds
+      })
     })
-  })
+    .finally(() => loader.hide())
 })
 </script>
 


### PR DESCRIPTION
This introduces usage of data.gouv.fr's API v2, [especially the new topic's one](https://github.com/opendatateam/udata/pull/2913).

- Fetch topic list via APIv2 and use the `tag` filter
- Deal with new response format from v2
  - Datasets from Topic need to be fetched via HATEOAS
  - Resources from Dataset need to be fetched via HATEOAS

This is the minimum viable implementation I can think of. We could migrate more stuff to v2, especially datasets, but ATM we use it only when we need and use both v1 and v2.

I did not look into Topic write operations since they're not available on frontend anymore (when I started this morning, might have changed since then).

~~NB: [`npm run format`](https://github.com/ecolabdata/ecospheres-front/pull/154/commits/a1d11498e1b37c636018e1b38a45e6e44b9077b0) makes a lot of unrelated changes, sorry. I don't understand why, since this command should have been run on the other PRs. Maybe we should make it a part of CI or pre-commit hook.~~