### PR TITLE
Recap page after creating bouquet from step 1 to 3

### DIFF
--- a/src/views/bouquets/BouquetEditView.vue
+++ b/src/views/bouquets/BouquetEditView.vue
@@ -516,6 +516,7 @@ onMounted(() => {
             >
               <DsfrAccordion
                 :title="datasetProperties.title"
+                :id="datasetProperties.id"
                 :expanded-id="datasetProperties.id"
                 @expand="datasetProperties.id = $event"
               >

--- a/src/views/bouquets/BouquetEditView.vue
+++ b/src/views/bouquets/BouquetEditView.vue
@@ -424,8 +424,6 @@ onMounted(() => {
           <div class="fr-col-12">
             <fieldset class="fr-fieldset">
               <div class="fr-fieldset__content" role="radiogroup">
-                {{ availabilityEnum.ECO_AVAILABLE }} --
-                {{ availabilityEnum.URL_AVAILABLE }}
                 <DsfrRadioButton
                   v-model="DatasetRetrievalOption"
                   :value="availabilityEnum.ECO_AVAILABLE"
@@ -697,7 +695,6 @@ onMounted(() => {
           <DsfrButton
             type="button"
             class="fr-mt-2w fr-mr-2w"
-            :secondary="true"
             label="Précédent"
             @click.prevent="validateAndMoveToStep(3)"
           />

--- a/src/views/bouquets/BouquetEditView.vue
+++ b/src/views/bouquets/BouquetEditView.vue
@@ -108,6 +108,11 @@ const availabilityEnum = {
   URL_AVAILABLE: 'url available'
 }
 
+const goToDatasetPage = (id) => {
+  const url = config.website.menu_items.find((link) => link.linkPage === '/datasets')
+  return `${url.linkPage}/${id}`
+}
+
 const addDatasetsPropertiesToExtras = async () => {
   const setUri = urlData.value ? urlData.value : null
   if (title.value && description.value) {
@@ -122,7 +127,7 @@ const addDatasetsPropertiesToExtras = async () => {
         datasetsProperties.value[datasetsPropertiesKey].push({
           title: title.value,
           description: description.value,
-          uri: dataset.page,
+          uri: goToDatasetPage(selectedDataset.value.id),
           id: selectedDataset.value.id,
           available: availabilityEnum.ECO_AVAILABLE
         })
@@ -643,6 +648,7 @@ onMounted(() => {
             >
               <DsfrAccordion
                 :title="datasetProperties.title"
+                :id="datasetProperties.id"
                 :expanded-id="datasetProperties.id"
                 @expand="datasetProperties.id = $event"
               >


### PR DESCRIPTION
Feature proposal Recap page
Fix #151 

### Job story

After filling in the bouquet creation information in steps 1, 2 and 3, I can view the pre-filled information, validate it or modify it if necessary by returning to the previous steps by clicking on the pencil icons.

#### Technical changes

- Useless code was appearing on step3, I removed it
- Keep accordion open

#### Screen view

![capture](https://github.com/ecolabdata/ecospheres-front/assets/11522622/9133dcc6-03b4-4141-aa4d-2ecd6773b6be)



