### PR TITLE
feat(bouquet): visualisation d'un bouquet

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -61,6 +61,7 @@ website:
 themes:
   - name: Se loger
     color: 043574
+    textColor: FFFFFF
     subthemes:
       - name: Construction et rénovation des logements
       - name: Aménagements des villes

--- a/src/views/bouquets/BouquetDetailView.vue
+++ b/src/views/bouquets/BouquetDetailView.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { DsfrButton } from '@gouvminint/vue-dsfr'
 import { onMounted, ref, computed } from 'vue'
 import { useLoading } from 'vue-loading-overlay'
 import { useRoute, useRouter } from 'vue-router'
@@ -9,7 +10,6 @@ import { useDatasetStore } from '../../store/DatasetStore'
 import { useTopicStore } from '../../store/TopicStore'
 import { useUserStore } from '../../store/UserStore'
 import { descriptionFromMarkdown } from '../../utils'
-import { DsfrButton } from '@gouvminint/vue-dsfr'
 
 const route = useRoute()
 const router = useRouter()
@@ -26,8 +26,8 @@ const description = computed(() => descriptionFromMarkdown(bouquet))
 
 const breadcrumbLinks = ref([
   {
-    "to": "/",
-    "text": "Accueil"
+    to: '/',
+    text: 'Accueil'
   }
 ])
 const selectedTheme = ref('')
@@ -54,11 +54,13 @@ const copyUrl = () => {
 }
 
 const getThemeColor = (themeName) => {
-  const theme = config.themes.find(theme => theme.name === themeName)
-  return theme ? `#${parseInt(theme.color, 16).toString(16).padStart(6, '0')}` : 'transparent'
+  const theme = config.themes.find((theme) => theme.name === themeName)
+  return theme
+    ? `#${parseInt(theme.color, 16).toString(16).padStart(6, '0')}`
+    : 'transparent'
 }
 
-const getSelectedThemeColor = themed => {
+const getSelectedThemeColor = (themed) => {
   selectedTheme.value = themed
   return getThemeColor(selectedTheme.value)
 }
@@ -77,8 +79,10 @@ onMounted(() => {
     .load(route.params.bid)
     .then((res) => {
       bouquet.value = res
-      theme.value = bouquet.value.extras[`${config.universe.name}:informations`][0].theme
-      subtheme.value = bouquet.value.extras[`${config.universe.name}:informations`][0].subtheme
+      theme.value =
+        bouquet.value.extras[`${config.universe.name}:informations`][0].theme
+      subtheme.value =
+        bouquet.value.extras[`${config.universe.name}:informations`][0].subtheme
 
       breadcrumbLinks.value.push(
         {
@@ -110,7 +114,17 @@ onMounted(() => {
       :tertiary="true"
       :no-outline="true"
     >
-      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"><path fill="currentColor" d="m5.828 7l2.536 2.535L6.95 10.95L2 6l4.95-4.95l1.414 1.415L5.828 5H13a8 8 0 1 1 0 16H4v-2h9a6 6 0 0 0 0-12H5.828Z"/></svg> 
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+      >
+        <path
+          fill="currentColor"
+          d="m5.828 7l2.536 2.535L6.95 10.95L2 6l4.95-4.95l1.414 1.415L5.828 5H13a8 8 0 1 1 0 16H4v-2h9a6 6 0 0 0 0-12H5.828Z"
+        />
+      </svg>
       Revenir aux résultats
     </DsfrButton>
     <DsfrBreadcrumb :links="breadcrumbLinks" />
@@ -152,30 +166,28 @@ onMounted(() => {
               `${config.universe.name}:datasets_properties`
             ]"
           >
-          <!-- {{ datasetProperties }} -->
+            <!-- {{ datasetProperties }} -->
             <DsfrAccordion
               :title="datasetProperties.title"
               :id="datasetProperties.id"
               :expanded-id="datasetProperties.id"
               @expand="datasetProperties.id = $event"
             >
-            <DsfrTag
-                  v-if="
-                    datasetProperties.available !==
-                      availabilityEnum.URL_AVAILABLE &&
-                    datasetProperties.available !==
-                      availabilityEnum.ECO_AVAILABLE
-                  "
-                  class="fr-mb-2w uppercase bold"
-                  :label="`${
-                    datasetProperties.available ===
-                    availabilityEnum.NOT_AVAILABLE
-                      ? missingData
-                      : datasetProperties.available === availabilityEnum.MISSING
-                      ? notFoundData
-                      : null
-                  }`"
-                />
+              <DsfrTag
+                v-if="
+                  datasetProperties.available !==
+                    availabilityEnum.URL_AVAILABLE &&
+                  datasetProperties.available !== availabilityEnum.ECO_AVAILABLE
+                "
+                class="fr-mb-2w uppercase bold"
+                :label="`${
+                  datasetProperties.available === availabilityEnum.NOT_AVAILABLE
+                    ? missingData
+                    : datasetProperties.available === availabilityEnum.MISSING
+                    ? notFoundData
+                    : null
+                }`"
+              />
               <div class="fr-mb-3w">
                 {{ datasetProperties.description }}
               </div>
@@ -192,7 +204,12 @@ onMounted(() => {
       </div>
     </div>
 
-    <DsfrButton @click.prevent="copyUrl" icon="ri-copy" :inline="false" class="btn-copy fr-ml-auto">
+    <DsfrButton
+      @click.prevent="copyUrl"
+      icon="ri-copy"
+      :inline="false"
+      class="btn-copy fr-ml-auto"
+    >
       Copier l'url de la page
     </DsfrButton>
   </div>
@@ -243,6 +260,6 @@ onMounted(() => {
   }
 }
 .btn-copy {
-  display: block ;
+  display: block;
 }
 </style>

--- a/src/views/bouquets/BouquetDetailView.vue
+++ b/src/views/bouquets/BouquetDetailView.vue
@@ -87,11 +87,11 @@ onMounted(() => {
       breadcrumbLinks.value.push(
         {
           text: theme,
-          to: `/?theme=${theme.value}`
+          to: `/bouquets/?theme=${theme.value}`
         },
         {
           text: subtheme.value,
-          to: `/?theme=${theme.value}&subtheme=${subtheme.value}`
+          to: `/bouquets/?theme=${theme.value}&subtheme=${subtheme.value}`
         },
         {
           text: bouquet.value.name
@@ -108,8 +108,9 @@ onMounted(() => {
 
 <template>
   <div class="fr-container--fluid fr-mt-4w fr-mb-4w">
+    <DsfrBreadcrumb :links="breadcrumbLinks" class="fr-mb-2w" />
     <DsfrButton
-      class="backToPage fr-pl-0"
+      class="backToPage fr-pl-0 fr-mb-2w"
       @click.prevent="goBack"
       :tertiary="true"
       :no-outline="true"
@@ -127,7 +128,6 @@ onMounted(() => {
       </svg>
       Revenir aux résultats
     </DsfrButton>
-    <DsfrBreadcrumb :links="breadcrumbLinks" />
     <div class="bouquet__header fr-mb-4w">
       <div class="bouquet__header__left">
         <h3 class="fr-mb-3w fr-mb-md-0 fr-mr-md-3w">{{ bouquet.name }}</h3>
@@ -272,8 +272,6 @@ onMounted(() => {
       text-align: center;
     }
   }
-
-
 }
 .btn-copy {
   display: block;

--- a/src/views/bouquets/BouquetDetailView.vue
+++ b/src/views/bouquets/BouquetDetailView.vue
@@ -53,11 +53,23 @@ const copyUrl = () => {
   navigator.clipboard.writeText(url)
 }
 
-const getThemeColor = (themeName) => {
+const getTheme = (themeName) => {
   const theme = config.themes.find((theme) => theme.name === themeName)
+  return theme
+}
+
+const getThemeColor = (themeName) => {
+  const theme = getTheme(themeName)
   return theme
     ? `#${parseInt(theme.color, 16).toString(16).padStart(6, '0')}`
     : 'transparent'
+}
+
+const getTextColor = (themeName) => {
+  const theme = getTheme(themeName)
+  return theme
+    ? `#${parseInt(theme.textColor, 16).toString(16).padStart(6, '0')}`
+    : '#000000b3'
 }
 
 const getSelectedThemeColor = (themed) => {
@@ -135,7 +147,10 @@ onMounted(() => {
           v-if="bouquet.extras"
           class="fr-mb-3w fr-mb-md-0 bold uppercase"
           :label="subtheme"
-          :style="{ backgroundColor: getSelectedThemeColor(theme) }"
+          :style="{
+            backgroundColor: getSelectedThemeColor(theme),
+            color: getTextColor(theme)
+          }"
         />
       </div>
       <DsfrButton

--- a/src/views/bouquets/BouquetDetailView.vue
+++ b/src/views/bouquets/BouquetDetailView.vue
@@ -58,18 +58,18 @@ const getTheme = (themeName) => {
   return theme
 }
 
+const convertToHex = (hex, color) => {
+  return hex ? `#${parseInt(hex, 16).toString(16).padStart(6, '0')}` : color
+}
+
 const getThemeColor = (themeName) => {
   const theme = getTheme(themeName)
-  return theme
-    ? `#${parseInt(theme.color, 16).toString(16).padStart(6, '0')}`
-    : 'transparent'
+  return convertToHex(theme ? theme.color : 'transparent')
 }
 
 const getTextColor = (themeName) => {
   const theme = getTheme(themeName)
-  return theme
-    ? `#${parseInt(theme.textColor, 16).toString(16).padStart(6, '0')}`
-    : '#000000b3'
+  return convertToHex(theme ? theme.textColor : '#000000b3')
 }
 
 const getSelectedThemeColor = (themed) => {

--- a/src/views/bouquets/BouquetDetailView.vue
+++ b/src/views/bouquets/BouquetDetailView.vue
@@ -9,6 +9,7 @@ import { useDatasetStore } from '../../store/DatasetStore'
 import { useTopicStore } from '../../store/TopicStore'
 import { useUserStore } from '../../store/UserStore'
 import { descriptionFromMarkdown } from '../../utils'
+import { DsfrButton } from '@gouvminint/vue-dsfr'
 
 const route = useRoute()
 const router = useRouter()
@@ -16,13 +17,50 @@ const store = useTopicStore()
 const userStore = useUserStore()
 const datasetStore = useDatasetStore()
 const bouquet = ref({})
+const theme = ref()
+const subtheme = ref()
 const datasets = ref([])
 const loading = useLoading()
 
 const description = computed(() => descriptionFromMarkdown(bouquet))
 
+const breadcrumbLinks = ref([
+  {
+    "to": "/",
+    "text": "Accueil"
+  }
+])
+const selectedTheme = ref('')
+const url = window.location.href
+const availabilityEnum = {
+  MISSING: 'missing',
+  NOT_AVAILABLE: 'not available',
+  ECO_AVAILABLE: 'available',
+  URL_AVAILABLE: 'url available'
+}
+const missingData = 'Donnée manquante'
+const notFoundData = 'Donnée non disponible'
+
 const goToCreate = () => {
   router.push({ name: 'bouquet_add' })
+}
+
+const goBack = () => {
+  router.go(-1)
+}
+
+const copyUrl = () => {
+  navigator.clipboard.writeText(url)
+}
+
+const getThemeColor = (themeName) => {
+  const theme = config.themes.find(theme => theme.name === themeName)
+  return theme ? `#${parseInt(theme.color, 16).toString(16).padStart(6, '0')}` : 'transparent'
+}
+
+const getSelectedThemeColor = themed => {
+  selectedTheme.value = themed
+  return getThemeColor(selectedTheme.value)
 }
 
 const canCreate = computed(() => {
@@ -39,6 +77,22 @@ onMounted(() => {
     .load(route.params.bid)
     .then((res) => {
       bouquet.value = res
+      theme.value = bouquet.value.extras[`${config.universe.name}:informations`][0].theme
+      subtheme.value = bouquet.value.extras[`${config.universe.name}:informations`][0].subtheme
+
+      breadcrumbLinks.value.push(
+        {
+          text: theme,
+          to: `/?theme=${theme.value}`
+        },
+        {
+          text: subtheme.value,
+          to: `/?theme=${theme.value}&subtheme=${subtheme.value}`
+        },
+        {
+          text: bouquet.value.name
+        }
+      )
       // FIXME: not used anymore in template below, change template or remove
       return datasetStore.loadMultiple(res.datasets).then((ds) => {
         datasets.value = ds
@@ -50,15 +104,24 @@ onMounted(() => {
 
 <template>
   <div class="fr-container--fluid fr-mt-4w fr-mb-4w">
+    <DsfrButton
+      class="backToPage fr-pl-0"
+      @click.prevent="goBack"
+      :tertiary="true"
+      :no-outline="true"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"><path fill="currentColor" d="m5.828 7l2.536 2.535L6.95 10.95L2 6l4.95-4.95l1.414 1.415L5.828 5H13a8 8 0 1 1 0 16H4v-2h9a6 6 0 0 0 0-12H5.828Z"/></svg> 
+      Revenir aux résultats
+    </DsfrButton>
+    <DsfrBreadcrumb :links="breadcrumbLinks" />
     <div class="bouquet__header fr-mb-4w">
       <div class="bouquet__header__left">
-        <h3 class="fr-m-0">{{ bouquet.name }}</h3>
+        <h3 class="fr-mb-3w fr-mb-md-0 fr-mr-md-3w">{{ bouquet.name }}</h3>
         <DsfrTag
           v-if="bouquet.extras"
-          class="fr-ml-3w"
-          :label="
-            bouquet.extras[`${config.universe.name}:informations`][0].subtheme
-          "
+          class="fr-mb-3w fr-mb-md-0 bold uppercase"
+          :label="subtheme"
+          :style="{ backgroundColor: getSelectedThemeColor(theme) }"
         />
       </div>
       <DsfrButton
@@ -68,7 +131,7 @@ onMounted(() => {
         @click="goToCreate"
       />
     </div>
-    <div class="bouquet__container fr-p-6w">
+    <div class="bouquet__container fr-p-6w fr-mb-6w">
       <h5><strong>Objectif du bouquet</strong></h5>
       <div v-html="description" />
       <div
@@ -89,17 +152,36 @@ onMounted(() => {
               `${config.universe.name}:datasets_properties`
             ]"
           >
+          <!-- {{ datasetProperties }} -->
             <DsfrAccordion
               :title="datasetProperties.title"
+              :id="datasetProperties.id"
               :expanded-id="datasetProperties.id"
               @expand="datasetProperties.id = $event"
             >
+            <DsfrTag
+                  v-if="
+                    datasetProperties.available !==
+                      availabilityEnum.URL_AVAILABLE &&
+                    datasetProperties.available !==
+                      availabilityEnum.ECO_AVAILABLE
+                  "
+                  class="fr-mb-2w uppercase bold"
+                  :label="`${
+                    datasetProperties.available ===
+                    availabilityEnum.NOT_AVAILABLE
+                      ? missingData
+                      : datasetProperties.available === availabilityEnum.MISSING
+                      ? notFoundData
+                      : null
+                  }`"
+                />
               <div class="fr-mb-3w">
                 {{ datasetProperties.description }}
               </div>
               <a
                 v-if="datasetProperties.uri"
-                class="fr-btn fr-btn--secondary block fr-ml-auto"
+                class="fr-btn fr-btn--secondary flex fr-ml-auto"
                 :href="datasetProperties.uri"
                 target="_blank"
                 >Accéder au catalogue</a
@@ -109,19 +191,46 @@ onMounted(() => {
         </DsfrAccordionsGroup>
       </div>
     </div>
+
+    <DsfrButton @click.prevent="copyUrl" icon="ri-copy" :inline="false" class="btn-copy fr-ml-auto">
+      Copier l'url de la page
+    </DsfrButton>
   </div>
 </template>
 
 <style scoped lang="scss">
+.backToPage {
+  color: var(--text-action-high-blue-france);
+  text-decoration: none;
+
+  svg {
+    margin-right: 5px;
+    vertical-align: middle;
+  }
+}
+
 .bouquet {
   &__header {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    flex-flow: wrap;
+
+    // @media (max-width: 640px) {
+    //   min-height: 100vh;
+    //   display: flex;
+    //   align-items: center;
+    // }
 
     &__left {
       display: flex;
       align-items: center;
+      flex-flow: wrap;
+
+      .fr-tag {
+        color: rgba(0, 0, 0, 0.7);
+        border-radius: 0;
+      }
     }
   }
 
@@ -132,5 +241,8 @@ onMounted(() => {
       color: var(--text-action-high-blue-france);
     }
   }
+}
+.btn-copy {
+  display: block ;
 }
 </style>

--- a/src/views/bouquets/BouquetDetailView.vue
+++ b/src/views/bouquets/BouquetDetailView.vue
@@ -166,7 +166,6 @@ onMounted(() => {
               `${config.universe.name}:datasets_properties`
             ]"
           >
-            <!-- {{ datasetProperties }} -->
             <DsfrAccordion
               :title="datasetProperties.title"
               :id="datasetProperties.id"
@@ -191,13 +190,27 @@ onMounted(() => {
               <div class="fr-mb-3w">
                 {{ datasetProperties.description }}
               </div>
-              <a
-                v-if="datasetProperties.uri"
-                class="fr-btn fr-btn--secondary flex fr-ml-auto"
-                :href="datasetProperties.uri"
-                target="_blank"
-                >Accéder au catalogue</a
-              >
+              <div class="button__wrapper">
+                <a
+                  v-if="
+                    datasetProperties.available !==
+                      availabilityEnum.URL_AVAILABLE &&
+                    datasetProperties.available !==
+                      availabilityEnum.ECO_AVAILABLE
+                  "
+                  class="fr-btn fr-btn--secondary inline-flex"
+                  :href="`mailto:${config.website.contact_email}`"
+                >
+                  Aidez-nous à trouver la donnée</a
+                >
+                <a
+                  v-else
+                  class="fr-btn fr-btn--secondary inline-flex"
+                  :href="datasetProperties.uri"
+                  target="_blank"
+                  >Accéder au catalogue</a
+                >
+              </div>
             </DsfrAccordion>
           </li>
         </DsfrAccordionsGroup>
@@ -233,12 +246,6 @@ onMounted(() => {
     justify-content: space-between;
     flex-flow: wrap;
 
-    // @media (max-width: 640px) {
-    //   min-height: 100vh;
-    //   display: flex;
-    //   align-items: center;
-    // }
-
     &__left {
       display: flex;
       align-items: center;
@@ -257,7 +264,16 @@ onMounted(() => {
     :deep(a) {
       color: var(--text-action-high-blue-france);
     }
+
+    .button__wrapper {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      text-align: center;
+    }
   }
+
+
 }
 .btn-copy {
   display: block;


### PR DESCRIPTION
Close #112 

Visualisation de la page du bouquet

Après avoir rempli le formulaire de création de bouquet ou après avoir chercher un bouquet, j'accède à la page du bouquet avec les informations liés: thème, chantier, titre, description, jeux de données(si existant et trouvé)

Il y a la possibilité de créer un nouveau bouquet ou de copier l'url de la page

![screencapture-localhost-5173-bouquets-nourriture-2023-11-22-16_44_32](https://github.com/ecolabdata/ecospheres-front/assets/11522622/22a5c28a-765d-4118-bb44-966ddc0753ed)



