### PR TITLE
feat: allow filter menu item by adding property in configs

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -31,23 +31,28 @@ website:
       id: 'home'
       linkPage: '/'
       type: 'component'
+      display_menu: true
     - name: 'Jeux de données'
       id: 'datasets'
       linkPage: '/datasets'
       type: 'component'
+      display_menu: true
     - name: 'Organisations'
       id: 'organizations'
       linkPage: '/organizations'
       type: 'component'
+      display_menu: true
     - name: 'Bouquets'
       id: 'bouquets'
       linkPage: '/bouquets'
       type: 'component'
+      display_menu: true
     - name: 'À propos'
       id: 'about'
       linkPage: '/about'
       type: 'page'
       url: 'https://gist.githubusercontent.com/geoffreyaldebert/f6198f2aa63b18783be7d7d3be0909a9/raw/7f979217a4c878225262eb654be3136bf1fe7157/about.md'
+      display_menu: true
   home_buttons:
   show_topic_charts: false
   list_highlighted_topics:

--- a/configs/meteo-france/config.yaml
+++ b/configs/meteo-france/config.yaml
@@ -28,20 +28,24 @@ website:
       id: 'home'
       linkPage: '/'
       type: 'component'
+      display_menu: false
     - name: 'Jeux de données'
       id: 'datasets'
       linkPage: '/datasets'
       type: 'component'
+      display_menu: true
     - name: 'Informations'
       id: 'infos'
       linkPage: '/informations'
       type: 'page'
       url: 'https://raw.githubusercontent.com/etalab/datagouvfr-pages/master/pages/about/ressources.md'
+      display_menu: true
     - name: 'A propos'
       id: 'about'
       linkPage: '/about'
       type: 'page'
       url: 'https://raw.githubusercontent.com/etalab/datagouvfr-pages/master/pages/legal/charter.md'
+      display_menu: true
   # img should be square
   home_buttons:
     - title: 'En savoir plus sur la démarche'

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -6,10 +6,12 @@ import config from '@/config'
 const navItems = computed(() => {
   const items = []
   config.website.menu_items.forEach((item) => {
-    items.push({
-      to: item.linkPage,
-      text: item.name
-    })
+    if (item.display_menu) {
+      items.push({
+        to: item.linkPage,
+        text: item.name
+      })
+    }
   })
   return items
 })


### PR DESCRIPTION
Every menu items in config should not be displayed in menu items. For instance, no need of a home button because header is already linking to this page.

- parametrize filtering menu items in configs with a `display_menu` property