### PR TITLE
feat: allow secondary search rerouting to another page

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -26,6 +26,13 @@ website:
   logo_operator:
   homepage_title: 'Ecosphères'
   homepage_subtitle: 'Explorez les données ouvertes et restreintes de la <b>Transition écologique</b>, de la <b>Cohésion des territoires</b>, de la <b>Transition énergétique</b> et de la <b>Mer</b>'
+  search_bar: 
+    display: true
+    placeholder: 'Rechercher un jeu de données'
+  secondary_search: 
+    display: false
+    name:
+    link:
   menu_items:
     - name: 'Accueil'
       id: 'home'

--- a/configs/meteo-france/config.yaml
+++ b/configs/meteo-france/config.yaml
@@ -23,6 +23,13 @@ website:
   logo_operator: 'https://static.data.gouv.fr/avatars/81/6374003e904fad9ddac7436315fd15-100.png'
   homepage_title: 'La météo et le climat en Open Data'
   homepage_subtitle: 'meteo.data.gouv.fr centralise et structure les données publiques relatives à la météo et au climat.<br />Vous y trouverez des données brutes téléchargeables et utilisable de manière libre et gratuite.'
+  search_bar: 
+    display: true
+    placeholder: 'Rechercher un jeu de données'
+  secondary_search:     
+    display: true
+    name: 'Recherche guidée'
+    link: '/form'
   menu_items:
     - name: 'Accueil'
       id: 'home'

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -29,6 +29,12 @@ const topics = config.website.list_highlighted_topics
 const buttons = config.website.home_buttons
 const showTopicChart = config.website.show_topic_charts
 const colorsBanner = config.website.home_banner_colors
+const searchConfig = config.website.search_bar
+const secondarySearchConfig = config.website.secondary_search
+
+const goToPage = (page) => {
+  window.location.href = page
+}
 </script>
 
 <template>
@@ -49,14 +55,28 @@ const colorsBanner = config.website.home_banner_colors
       <div class="subtitle fr-mt-4w fr-mb-4w">
         <span v-html="homepageSubTitle" />
       </div>
-      <div class="search-bar">
+      <div class="search-bar" v-if="searchConfig.display">
         <DsfrSearchBar
           button-text="Rechercher"
-          placeholder="Rechercher un jeu de données"
-          :large="true"
+          :placeholder="searchConfig.placeholder"
+          :large="false"
           @search="doSearch"
           @update:modelValue="updateQuery"
+          class="search-bar-input"
+          :style="
+            secondarySearchConfig.display
+              ? 'min-width: 80%;'
+              : 'min-width: 100%;'
+          "
         />
+        <div v-if="secondarySearchConfig.display" class="or-sep">ou</div>
+        <div
+          v-if="secondarySearchConfig.display"
+          @click="goToPage(secondarySearchConfig.link)"
+          class="button-search-guided"
+        >
+          {{ secondarySearchConfig.name }}
+        </div>
       </div>
     </div>
   </div>
@@ -73,6 +93,27 @@ const colorsBanner = config.website.home_banner_colors
 </template>
 
 <style scoped lang="scss">
+@media (min-width: 1180px) {
+  .search-bar {
+    display: flex;
+    width: 100%;
+  }
+  .or-sep {
+    max-width: 30px;
+    margin-left: 20px;
+    margin-right: 20px;
+  }
+}
+@media (max-width: 1180px) {
+  .or-sep {
+    width: 100%;
+    margin-top: 10px;
+  }
+  .button-search-guided {
+    margin-top: 10px;
+  }
+}
+
 .fr-container {
   text-align: center;
 }
@@ -100,5 +141,27 @@ const colorsBanner = config.website.home_banner_colors
   padding: 20px;
   background-color: white;
   border-radius: 10px;
+}
+.search-bar-input {
+  flex-wrap: nowrap;
+  height: 40px;
+}
+.button-search-guided {
+  background-color: #060091;
+  padding-left: 10px;
+  padding-right: 10px;
+  color: white;
+  font-weight: bold;
+  vertical-align: middle;
+  line-height: 40px;
+  height: 40px;
+  border-radius: 20px;
+}
+.button-search-guided:hover {
+  cursor: pointer;
+}
+.or-sep {
+  text-align: 'center';
+  line-height: 40px;
 }
 </style>


### PR DESCRIPTION
! important : need to merge #184 first because it is based on `feat/colored-banner`

- parametrize a secondary search in homepage (useful for meteo.data.gouv.fr use case where they need a guided search)