### PR TITLE
build: fix typescript in vscode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["Vue.volar", "Vue.vscode-typescript-vue-plugin"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@testing-library/vue": "^8.0.0",
         "@trivago/prettier-plugin-sort-imports": "^1.4.4",
         "@tsconfig/node18": "^18.2.2",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.9.1",
         "@typescript-eslint/eslint-plugin": "^6.11.0",
         "@typescript-eslint/parser": "^6.11.0",
@@ -1106,6 +1107,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.3.tgz",
       "integrity": "sha512-jd+Q+sD20Qfu9e2aEXogiO3vpOC1PYJOUdyN9gvs4Qrvkg4wF43L5OhqrPeokdv8TL0/mXoYfpkcoGZMNN2pkQ==",
+      "dev": true
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true
     },
     "node_modules/@types/json-schema": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@testing-library/vue": "^8.0.0",
     "@trivago/prettier-plugin-sort-imports": "^1.4.4",
     "@tsconfig/node18": "^18.2.2",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.9.1",
     "@typescript-eslint/eslint-plugin": "^6.11.0",
     "@typescript-eslint/parser": "^6.11.0",

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -3,5 +3,6 @@
     "noEmit": true,
     "types": ["vitest/globals"]
   },
-  "extends": ["./tsconfig.json"]
+  "extends": ["./tsconfig.json"],
+  "include": ["**/*.ts"]
 }

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "noEmit": true,
     "types": ["vitest/globals"]
   },
   "extends": ["./tsconfig.json"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "allowJs": true,
     "experimentalDecorators": true,
+    "noEmit": true,
     "paths": {
       "@/*": ["./src/*"]
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,6 @@
   "extends": [
     "@tsconfig/node18/tsconfig.json",
     "@vue/tsconfig/tsconfig.dom.json"
-  ]
+  ],
+  "include": ["vite.config.ts", "**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "@tsconfig/node18/tsconfig.json",
     "@vue/tsconfig/tsconfig.dom.json"
   ],
-  "include": ["vite.config.ts", "**/*.ts"]
+  "include": ["**/*.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,12 +7,18 @@ import { resolve } from 'path'
 import { defineConfig, loadEnv } from 'vite'
 import { createHtmlPlugin } from 'vite-plugin-html'
 
+interface Config {
+  website: {
+    title: string
+  }
+}
+
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
   const configDir = `./configs/${env.CONFIG_NAME}`
   const configFileUrl = new URL(`${configDir}/config.yaml`, import.meta.url)
-  const config = load(readFileSync(configFileUrl))
+  const config = load(readFileSync(configFileUrl, 'utf-8')) as Config
   return {
     base: '/',
     plugins: [


### PR DESCRIPTION
Closes #175

## Amélioration technique

### Contexte

TypeScript devrait marcher sur [VSCode](https://code.visualstudio.com/).

### Problème

Ce n'est pas le cas: 

<img width="762" alt="Capture d’écran 2023-11-22 à 15 23 42" src="https://github.com/ecolabdata/ecospheres-front/assets/119625/f8ed3ef9-83fe-4a18-a661-52fc7910d424">

<img width="770" alt="Capture d’écran 2023-11-22 à 15 23 36" src="https://github.com/ecolabdata/ecospheres-front/assets/119625/2e1d01d3-5e59-4da2-a2cc-c24c0a763204">

<img width="983" alt="Capture d’écran 2023-11-22 à 15 23 51" src="https://github.com/ecolabdata/ecospheres-front/assets/119625/4a52dd5b-fe53-43ee-9edc-0dc299f5ebc7">

Via @abulte 

### Proposition de solution au problème

- Intègre le config `vite` et `.vscode`

### Que change ?

#### Modifications techniques

- 🛠 Inclut `include` dans `tsconfig.json` et `tsconfig.dev.json` (les configs `path` ne sont pas héritables)
- 🛠 Inclut les config `volar` et `typescript` dans `.vscode`