### PR TITLE
build(npm): fix husky et applique format

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,20 +5,20 @@ name: Run tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ['main']
   pull_request:
-    branches: [ "main" ]
+    branches: ['main']
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: 18.x
-        cache: 'npm'
-    - run: npm ci
-    - run: npm run build --if-present
-    - run: npm run test_single_run
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm run test_single_run

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test_single_run": "vitest run",
     "lint": "eslint . --ext .js,.ts,.vue,.json --ignore-path .gitignore",
     "hint": "tsc --project tsconfig.dev.json",
-    "format": "prettier . --write",
+    "format": "prettier '**/*.{js,ts,vue,yml,yaml,json}' --write",
     "prepare": "husky install"
   },
   "dependencies": {
@@ -68,6 +68,6 @@
     "vitest": "^0.34.6"
   },
   "lint-staged": {
-    "*": "prettier --write"
+    "*.{js,ts,vue,yml,yaml,json}": "prettier --write"
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,6 @@
     "vitest": "^0.34.6"
   },
   "lint-staged": {
-    "*.{js,ts,vue,json}": "prettier . --write"
+    "*": "prettier --write"
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,6 @@
     "vitest": "^0.34.6"
   },
   "lint-staged": {
-    "*.{js,ts,vue,json}": "prettier --write"
+    "*.{js,ts,vue,json}": "prettier . --write"
   }
 }

--- a/src/views/bouquets/BouquetEditView.vue
+++ b/src/views/bouquets/BouquetEditView.vue
@@ -109,7 +109,9 @@ const availabilityEnum = {
 }
 
 const goToDatasetPage = (id) => {
-  const url = config.website.menu_items.find((link) => link.linkPage === '/datasets')
+  const url = config.website.menu_items.find(
+    (link) => link.linkPage === '/datasets'
+  )
   return `${url.linkPage}/${id}`
 }
 


### PR DESCRIPTION
Relates to #191

## Amélioration technique

### Contexte

Lorsque je commit,
je m'attends à ce que le pre-commit hook applique `npm run format`.

### Problème

Ce n'est pas le cas, cf. #191

### Solution

Quand je commit, tout es bien formatté.

### Qu'est-ce qui change ?

#### Modifications techniques

- 🛠 Ajoute la racine (`.`) dans `lint-staged`.