### PR TITLE
ADR: change schéma pour trame de bouquet

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,9 @@ TL;DR:
 - Communication is in [French](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000006421209).
 - Code and code documentation are in [English (BR)](https://en.wikipedia.org/wiki/English_as_a_lingua_franca).
 - Code documentation is in the [JSDoc](https://jsdoc.app/) format.
-- Any other documentation is in French and can be found in the [docs](docs).
 - Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
-- Code styling is programmatically enforced and follows [Standard](https://standardjs.com/).
-- Testing is done with [Vitest](https://vutest.dev) and [Cypress](https://www.cypress.io/).
+- Code styling is progamatically enforced and follows [Standard](https://standardjs.com/).
+- Testing is done with [Vutest](https://vutest.dev) and [Cypress](https://www.cypress.io/).
 - Pull requests, reviews, and merging, follow [GitHub Flow](https://guides.github.com/introduction/flow/).
 - Change advertising follows [SemVer](http://semver.org/).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,10 @@ TL;DR:
 - Communication is in [French](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000006421209).
 - Code and code documentation are in [English (BR)](https://en.wikipedia.org/wiki/English_as_a_lingua_franca).
 - Code documentation is in the [JSDoc](https://jsdoc.app/) format.
+- Any other documentation is in French and can be found in the [docs](docs).
 - Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
-- Code styling is progamatically enforced and follows [Standard](https://standardjs.com/).
-- Testing is done with [Vutest](https://vutest.dev) and [Cypress](https://www.cypress.io/).
+- Code styling is programmatically enforced and follows [Standard](https://standardjs.com/).
+- Testing is done with [Vitest](https://vutest.dev) and [Cypress](https://www.cypress.io/).
 - Pull requests, reviews, and merging, follow [GitHub Flow](https://guides.github.com/introduction/flow/).
 - Change advertising follows [SemVer](http://semver.org/).
 

--- a/docs/architecture-decisions/1-change-schema-pour-trame-de-bouquet.md
+++ b/docs/architecture-decisions/1-change-schema-pour-trame-de-bouquet.md
@@ -1,0 +1,19 @@
+# Change schéma pour trame de bouquet
+
+## État
+
+✅ Acceptée ([RFC #1](../requests-for-comments/1-changer-le-nom-schema-de-bouquet.md))
+
+## Contexte
+
+Le périmètre d'Écosphères comprend la notion de « schéma de bouquet ». Le terme
+s'est avéré confus. Une discussion a eu lieu pour en trouver un meilleur terme.
+
+## Décision
+
+Utiliser le terme « trame de bouquet » à la place.
+
+## Conséquences
+
+- Mettre à jour les issues Github
+- Mettre à jour d'autres supports de communication

--- a/docs/requests-for-comments/1-changer-le-nom-schema-de-bouquet.md
+++ b/docs/requests-for-comments/1-changer-le-nom-schema-de-bouquet.md
@@ -1,0 +1,69 @@
+# Changer le nom « schéma de bouquet »
+
+## Contexte
+
+Le périmètre d'Écosphères comprend la notion de « schéma de bouquet ».
+
+Le terme renvoie à la notion d'un bouquet pré-rempli.
+
+Par exemple, un bouquet type pour un cas d'utilisation particulier.
+
+En extrapolant, si un bouquet était une lettre, un schéma serait un modèle de 
+lettre d'attestation sur l'honneur.
+
+## Problème
+
+Si l'on prend un schema comme la spécification d'un modèle de données, 
+l'utilisation du mot pour décrire la feature souhaitée ici est inappropriée.
+
+Voir exemple en [annexe](#annexe).
+
+## Discussion
+
+Une discussion asynchrone a eu lieu sur Slack entre le 25/11/2023 et le
+27/11/2023, où ont participé Gabriel, Johan, Martin, et Mauko.
+
+De la discussion ont émergé les propositions décrites ci-dessous.
+
+## Protocole
+
+Aucun protocole n'a été établi pour ce RFC.
+
+Malgré cela, les participants ont manifesté leurs préférences avec un 👍
+
+## Choix
+
+### Proposition 0 : garder le mot schéma
+
+Un schéma comprend les valeurs possibles d'un modèle de données et peut donc, 
+même si à contre-emploi, être utilisé pour décrire cette feature.
+
+### Proposition 1 : utiliser le mot template
+
+C'est un mot bien compris dans son sens courant, mais peut être confus pour 
+les dévs (cf. template `vuejs`).
+
+### Proposition 2 : utiliser le terme modèle de bouquet.
+
+C'est un terme bien compris dans son sens administratif, mais peut être 
+confondu avec - justement - schema de données.
+
+### Proposition 3 : utiliser le terme bouquet type
+
+C'est bien compris dans son sens courant, pas de contre-argument à signaler.
+
+### Proposition 4 : utiliser le terme trame de bouquet
+
+Schéma se réfère à plein d'autres choses qui ne ressemblent pas à ce que l'on 
+souhaite exprimer ici, qui est une trame de bouquet liée à un cas d'usage.
+
+## Conclusions
+
+- Proposition 2 👍
+- Proposition 4 👍👍👍
+
+**La proposition 4 est adoptée.**
+
+## Annexe
+
+- [Exemple de schéma de données](https://schema.data.gouv.fr/schemas/etalab/schema-irve-statique/2.2.0/schema-statique.json)


### PR DESCRIPTION
Closes #201 

## Change schéma pour trame de bouquet

### État

✅ Acceptée ([RFC #1](https://github.com/ecolabdata/ecospheres-front/blob/4f152d19afd0fdffcfa9c8a3c8a2f66779cd9642/docs/requests-for-comments/1-changer-le-nom-schema-de-bouquet.md))

### Contexte

Le périmètre d'Écosphères comprend la notion de « schéma de bouquet ». Le terme
s'est avéré confus. Une discussion a eu lieu pour en trouver un meilleur terme.

### Décision

Utiliser le terme « trame de bouquet » à la place.

### Actions

- Mettre à jour les issues Github
- Mettre à jour d'autres supports de communication
