### PR TITLE
Add mandatory links

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -61,6 +61,7 @@ website:
       type: 'page'
       display_menu: true
       url: '/ecospheres/pages/about.md'
+  mandatory_links: []
   home_buttons:
   show_topic_charts: false
   show_quality_component: true

--- a/configs/meteo-france/config.yaml
+++ b/configs/meteo-france/config.yaml
@@ -56,7 +56,7 @@ website:
       id: 'about'
       linkPage: '/about'
       type: 'page'
-      url: 'https://gist.githubusercontent.com/geoffreyaldebert/4e95103bff159c578db3941619fb9cfd/raw/7afdf99a23f45041e7e9eb391b65afeb6025e1cd/gistfile1.txt'
+      url: '/meteo-france/pages/about.md'
       display_menu: true
     - name: 'Accessibilité'
       id: 'accessibility'

--- a/configs/meteo-france/config.yaml
+++ b/configs/meteo-france/config.yaml
@@ -66,11 +66,11 @@ website:
       url: '/meteo-france/pages/accessibility.md'
   mandatory_links:
     - label: 'Licences'
-      to: 'https://www.data.gouv.fr/fr/pages/legal/licences'
+      to: '//www.data.gouv.fr/fr/pages/legal/licences/'
     - label: "Conditions générales d'utilisation"
-      to: 'https://www.data.gouv.fr/fr/terms/'
+      to: '//www.data.gouv.fr/fr/terms/'
     - label: 'Politique de confidentialité'
-      to: 'https://www.data.gouv.fr/fr/suivi/'
+      to: '//www.data.gouv.fr/fr/suivi/'
     - label: 'Accessibilité : non conforme'
       to: '/accessibility'
   # img should be square

--- a/configs/meteo-france/config.yaml
+++ b/configs/meteo-france/config.yaml
@@ -58,6 +58,21 @@ website:
       type: 'page'
       url: 'https://gist.githubusercontent.com/geoffreyaldebert/4e95103bff159c578db3941619fb9cfd/raw/7afdf99a23f45041e7e9eb391b65afeb6025e1cd/gistfile1.txt'
       display_menu: true
+    - name: 'Accessibilité'
+      id: 'accessibility'
+      linkPage: '/accessibility'
+      type: 'page'
+      display_menu: false
+      url: '/meteo-france/pages/accessibility.md'
+  mandatory_links:
+    - label: 'Licences'
+      to: 'https://www.data.gouv.fr/fr/pages/legal/licences'
+    - label: "Conditions générales d'utilisation"
+      to: 'https://www.data.gouv.fr/fr/terms/'
+    - label: 'Politique de confidentialité'
+      to: 'https://www.data.gouv.fr/fr/suivi/'
+    - label: 'Accessibilité : non conforme'
+      to: '/accessibility'
   # img should be square
   home_buttons:
   show_topic_charts: true

--- a/public/meteo-france/pages/about.md
+++ b/public/meteo-france/pages/about.md
@@ -1,0 +1,51 @@
+# ***À propos de meteo.data.gouv.fr***
+
+### **Qu’est-ce que [meteo.data.gouv.fr](http://meteo.data.gouv.fr/) ?**
+
+[meteo.data.gouv.fr](http://meteo.data.gouv.fr/) est une plateforme qui centralise et structure les données publiques relatives à la météo et au climat.
+
+### **À qui s’adresse [meteo.data.gouv.fr](http://meteo.data.gouv.fr/) ?**
+
+[meteo.data.gouv.fr](http://meteo.data.gouv.fr/) s’adresse aux réutilisateurs de données cherchant des données brutes téléchargeables et utilisables de manière libre et gratuite, qu'ils soient de l’administration, du secteur privé ou de la société civile.
+
+### **Les données ouvertes : qu’est-ce que c’est ?**
+
+Les données ouvertes (open data) sont des données en accès libre, gratuit et facilement réutilisables par toutes et tous. Ces données peuvent être produites par l’administration, mais aussi par des acteurs privés ou encore des citoyens.
+
+### **Quelles données sont mises à disposition ?**
+
+Lancée en décembre 2023, la plateforme a vocation à être enrichie de nouvelles données au fur et à mesure et de mettre en avant des données relatives à la météo et au climat.
+
+Les données déjà disponibles : 
+
+- Données climatologiques de base : données climatologiques de toutes les stations françaises depuis leur ouverture, pour tous les paramètres disponibles.
+- Données climatologiques de référence pour le changement climatique : données « mémoire du climat » qui permettent de constater les effets déjà observés du changement climatique.
+
+Les données suivantes seront bientôt disponibles : 
+
+- Données d’observation mesurées par les stations météorologiques ;
+- Alertes météorologiques ;
+- Données radar ;
+- Modèles de données de prévision météorologique numérique (PNT).
+
+### Une api sera t-elle disponible ?
+
+Les API de Météo-France disponible sur [ce portail](https://portail-api.meteofrance.fr/devportal/apis) seront bientôt référencées directement sur [meteo.data.gouv.fr](http://meteo.data.gouv.fr). 
+
+### **Un énième portail open data ?**
+
+[meteo.data.gouv.fr](http://meteo.data.gouv.fr/) n’est pas un nouveau portail open data. C’est une exposition thématique du catalogue de [data.gouv.fr](http://data.gouv.fr/) sur le modèle de [transport.data.gouv.fr](http://transport.data.gouv.fr/), par exemple. Toutes les données disponibles ici le sont dans les mêmes conditions sur [data.gouv.fr](http://data.gouv.fr/).
+
+### **Qui est derrière [meteo.data.gouv.fr](http://meteo.data.gouv.fr/) ?**
+
+Cette plateforme est le fruit d’une collaboration entre l’équipe [data.gouv.fr](http://data.gouv.fr/) de la Direction Interministérielle du Numérique et Météo-France.
+
+Celle-ci s’inscrit dans une démarche plus large de construction de biens communs numériques facilitant la création de plateformes thématiques exposant de la donnée publique.
+
+### Un retour, une question ?
+
+**[Vos retours](https://tally.so/r/wQ7y47)** sont bienvenus pour nous permettre d’améliorer la plateforme !
+
+Si vous avez une question qui porte sur les données vous pouvez *vous adresser à Météo-France*.
+
+Si vous avez une question spécifique sur le fonctionnement de la plateforme vous pouvez [écrire à l’équipe data.gouv.fr.](https://support.data.gouv.fr/)

--- a/public/meteo-france/pages/accessibility.md
+++ b/public/meteo-france/pages/accessibility.md
@@ -1,0 +1,32 @@
+# Déclaration d’accessibilité
+
+Établie le 11 décembre 2023.
+
+La Direction Interministérielle du Numérique s’engage à rendre son service accessible, conformément à l’article 47 de la loi n° 2005-102 du 11 février 2005.
+
+Cette déclaration d’accessibilité s’applique à meteo.data.gouv.fr (https://meteo.data.gouv.fr).
+
+## État de conformité
+
+meteo.data.gouv.fr est non conforme avec le RGAA. Le site n’a encore pas été audité.
+
+## Amélioration et contact
+
+Si vous n’arrivez pas à accéder à un contenu ou à un service, vous pouvez contacter le responsable de meteo.data.gouv.fr pour être orienté vers une alternative accessible ou obtenir le contenu sous une autre forme.
+
+    Formulaire de contact : https://support.data.gouv.fr/
+    Adresse : DINUM, Ségur, Paris
+
+## Voie de recours
+
+Cette procédure est à utiliser dans le cas suivant : vous avez signalé au responsable du site internet un défaut d’accessibilité qui vous empêche d’accéder à un contenu ou à un des services du portail et vous n’avez pas obtenu de réponse satisfaisante.
+
+Vous pouvez :
+
+* Écrire un message au Défenseur des droits
+* Contacter le délégué du Défenseur des droits dans votre région
+* Envoyer un courrier par la poste (gratuit, ne pas mettre de timbre) : 
+    Défenseur des droits
+    Libre réponse 71120 75342 Paris CEDEX 07
+
+Cette déclaration d’accessibilité a été créé le 11 décembre 2023 grâce au Générateur de Déclaration d’Accessibilité de BetaGouv.

--- a/src/App.vue
+++ b/src/App.vue
@@ -76,6 +76,7 @@ const logoService = ref(config.website.service_logo)
 const showBadge = ref(config.website.badge.display)
 const badgeText = ref(config.website.badge.text)
 const badgeStyle = ref(config.website.badge.style)
+const mandatoryLinks = ref(config.website.mandatory_links)
 </script>
 
 <template>
@@ -102,7 +103,7 @@ const badgeStyle = ref(config.website.badge.style)
 
   <RouterView />
 
-  <DsfrFooter class="fr-mt-8w" :mandatory-links="[]"></DsfrFooter>
+  <DsfrFooter class="fr-mt-8w" :mandatory-links="mandatoryLinks"></DsfrFooter>
 </template>
 
 <!-- global styles -->

--- a/src/App.vue
+++ b/src/App.vue
@@ -103,7 +103,16 @@ const mandatoryLinks = ref(config.website.mandatory_links)
 
   <RouterView />
 
-  <DsfrFooter class="fr-mt-8w" :mandatory-links="mandatoryLinks"></DsfrFooter>
+  <DsfrFooter class="fr-mt-8w" :mandatory-links="mandatoryLinks">
+    <template v-slot:description>
+      <p class="fr-text--sm">
+        Ce site est une déclinaison thématique de
+        <a href="https://www.data.gouv.fr/">data.gouv.fr</a> sur les données
+        relatives à la météo et au climat réalisé en collaboration avec
+        Météo-France.
+      </p>
+    </template>
+  </DsfrFooter>
 </template>
 
 <!-- global styles -->


### PR DESCRIPTION
Closes https://github.com/etalab/data.gouv.fr/issues/1230
Related to https://github.com/etalab/data.gouv.fr/issues/1224

1. Add mandatory links in footer in meteo config :
* Licences (link towards data.gouv.fr's)
* General Condition of Use (link towards data.gouv.fr's)
* Confidentiality policy (link towards data.gouv.fr's)
* Accessibility

2. A new page for accessibility declaration
Generated with https://betagouv.github.io/a11y-generateur-declaration/

3. Add .md pages in the repo (about and accessibility) following https://github.com/ecolabdata/ecospheres-front/pull/222

Visual result:
![image](https://github.com/ecolabdata/ecospheres-front/assets/28541902/17833971-59fa-4743-8f6a-6928632b1043)

# Critical issues

- [x] External links `https://www.data.gouv.fr/fr/pages/legal/licences` are treated as routes (http://localhost:5173/https://www.data.gouv.fr/fr/terms/) instead of external links. [Relevant lines](https://github.com/dnum-mi/vue-dsfr/blob/b6b1755cae5487a4be7554844f7252c6cb7ddcab/src/components/DsfrFooter/DsfrFooter.vue#L190).
    * Tried out [a random solution](https://stackoverflow.com/a/69237486) by a random user and it seems to work : https://github.com/ecolabdata/ecospheres-front/pull/247/commits/bf2fd337c1a7c1f487572d17f391af482e108ac9