### PR TITLE
Use spectral for subtitle

### DIFF
--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -50,11 +50,11 @@ const goToPage = (page) => {
       ');'
     "
   >
-    <div class="fr-container datagouv-components">
-      <h1 class="fr-display--xs text-align-left fr-mb-3v">
+    <div class="fr-container">
+      <h1 class="main-title fr-mb-3v">
         {{ homepageTitle }}
       </h1>
-      <div class="fr-text--lead fr-text--alt f-italic text-align-left fr-mb-4w">
+      <div class="subtitle fr-text--alt fr-mb-4w">
         <span v-html="markdown.render(homepageSubTitle)" />
       </div>
       <div class="search-bar" v-if="searchConfig.display">
@@ -138,6 +138,18 @@ const goToPage = (page) => {
   padding-top: 5%;
   padding-bottom: 5%;
   position: relative;
+}
+.main-title {
+  text-align: left;
+  font-size: 48px;
+  line-height: 50px;
+  font-weight: bold;
+}
+.subtitle {
+  text-align: left;
+  font-size: 20px;
+  line-height: 28px;
+  font-style: italic;
 }
 .search-bar {
   padding: 20px;

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -50,9 +50,11 @@ const goToPage = (page) => {
       ');'
     "
   >
-    <div class="fr-container">
-      <h1 class="main-title">{{ homepageTitle }}</h1>
-      <div class="subtitle fr-mt-4w fr-mb-4w">
+    <div class="fr-container datagouv-components">
+      <h1 class="fr-display--xs text-align-left fr-mb-3v">
+        {{ homepageTitle }}
+      </h1>
+      <div class="fr-text--lead fr-text--alt f-italic text-align-left fr-mb-4w">
         <span v-html="markdown.render(homepageSubTitle)" />
       </div>
       <div class="search-bar" v-if="searchConfig.display">
@@ -108,7 +110,7 @@ const goToPage = (page) => {
     margin-right: 20px;
   }
 }
-@media (max-width: 1180px) {
+@media (max-width: 1248px) {
   .or-sep {
     width: 100%;
     margin-top: 10px;
@@ -136,18 +138,6 @@ const goToPage = (page) => {
   padding-top: 5%;
   padding-bottom: 5%;
   position: relative;
-}
-.main-title {
-  text-align: left;
-  font-size: 48px;
-  line-height: 50px;
-  font-weight: bold;
-}
-.subtitle {
-  text-align: left;
-  font-size: 20px;
-  line-height: 28px;
-  font-style: italic;
 }
 .search-bar {
   padding: 20px;


### PR DESCRIPTION
Closes https://github.com/etalab/data.gouv.fr/issues/1231

##  Autre

### Qu'est-ce qui change ?

#### Nouvelles fonctionnalités

- 🤟 Utilisation de la font Spectral en italique pour le sous-titre

#### Modifications techniques

- 🛠 Refonte des styles du titre et du sous-titre pour utiliser les classes du DSFR et les utilitaires de data.gouv.fr-components
- 🛠 Correction de l'affichage de la search-bar sur les écrans entre 1180px et 1248px.
