### PR TITLE
fix(org): fix org detail page

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -58,6 +58,11 @@ website:
       linkPage: '/datasets'
       type: 'component'
       display_menu: true
+    - name: 'Organisations'
+      id: 'organizations'
+      linkPage: '/organizations'
+      type: 'component'
+      display_menu: false
     - name: 'Bouquets'
       id: 'bouquets'
       linkPage: '/bouquets'

--- a/src/services/api/resources/DatasetsAPI.js
+++ b/src/services/api/resources/DatasetsAPI.js
@@ -11,9 +11,9 @@ export default class DatasetsAPI extends DatagouvfrAPI {
    * @param {str?} sort
    * @returns {object}
    */
-  async getDatasetsForOrganization(org_id, page = 1, sort = '-created') {
+  async getDatasetsForOrganization(orgId, page = 1, sort = '-created') {
     // WARNING: specify `-created` or another sort explicitely because default sort has a pagination issue
-    const url = `${this.url()}/?organization=${org_id}&page=${page}&sort=${sort}&page_size=21`
+    const url = `${this.url()}/search/?organization=${orgId}&page=${page}&sort=${sort}&page_size=21`
     return await this.makeRequestAndHandleResponse(url)
   }
 }

--- a/src/store/DatasetStore.js
+++ b/src/store/DatasetStore.js
@@ -65,16 +65,16 @@ export const useDatasetStore = defineStore('dataset', {
      * @param {string?} sort Sort order requested
      * @returns {Array<object>}
      */
-    async loadDatasetsForOrg(orgId, page = 1, sort = '-created') {
-      const existing = this.getDatasetsForOrg(orgId, page, sort)
+    async loadDatasetsForOrg(org_id, page = 1, sort = '-created') {
+      const existing = this.getDatasetsForOrg(org_id, page, sort)
       if (existing.data) return existing
       const datasets = await datasetsApiv2.getDatasetsForOrganization(
-        orgId,
+        org_id,
         page,
         sort
       )
-      this.addDatasets(orgId, datasets, sort)
-      return this.getDatasetsForOrg(orgId, page, sort)
+      this.addDatasets(org_id, datasets, sort)
+      return this.getDatasetsForOrg(org_id, page, sort)
     },
     /**
      * Store the result of a datasets fetch operation for an org in store

--- a/src/store/DatasetStore.js
+++ b/src/store/DatasetStore.js
@@ -65,16 +65,16 @@ export const useDatasetStore = defineStore('dataset', {
      * @param {string?} sort Sort order requested
      * @returns {Array<object>}
      */
-    async loadDatasetsForOrg(org_id, page = 1, sort = '-created') {
-      const existing = this.getDatasetsForOrg(org_id, page, sort)
+    async loadDatasetsForOrg(orgId, page = 1, sort = '-created') {
+      const existing = this.getDatasetsForOrg(orgId, page, sort)
       if (existing.data) return existing
       const datasets = await datasetsApiv2.getDatasetsForOrganization(
-        org_id,
+        orgId,
         page,
         sort
       )
-      this.addDatasets(org_id, datasets, sort)
-      return this.getDatasetsForOrg(org_id, page, sort)
+      this.addDatasets(orgId, datasets, sort)
+      return this.getDatasetsForOrg(orgId, page, sort)
     },
     /**
      * Store the result of a datasets fetch operation for an org in store


### PR DESCRIPTION
Fix la page détail d'une organisation en utilisant le bon endpoint sur l'API v2. Réintroduit le routage vers une page organisation sur ecospheres, mais sans l'afficher dans le menu.

Related #238 
Related #211 