### PR TITLE
refacto: rename menu_items to router_items

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -47,7 +47,7 @@ website:
       href: 'https://www.data.gouv.fr/fr/terms/'
     - label: 'Politique de confidentialité'
       href: 'https://www.data.gouv.fr/fr/suivi/'
-  menu_items:
+  router_items:
     - name: 'Accueil'
       id: 'home'
       linkPage: '/'

--- a/configs/meteo-france/config.yaml
+++ b/configs/meteo-france/config.yaml
@@ -34,7 +34,7 @@ website:
     display: true
     name: 'Recherche guidée'
     link: '/form'
-  menu_items:
+  router_items:
     - name: 'Accueil'
       id: 'home'
       linkPage: '/'

--- a/configs/sante-publique-france/config.yaml
+++ b/configs/sante-publique-france/config.yaml
@@ -22,7 +22,7 @@ website:
   logo_operator: 'https://static.data.gouv.fr/avatars/76/69d8ead7684d25a80c9fa97d943b06-100.png'
   homepage_title: 'Données Santé Publique France'
   homepage_subtitle: 'Portail des données publiques open data de santé SPF'
-  menu_items:
+  router_items:
     - name: 'Accueil'
       id: 'home'
       linkPage: '/'

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -12,7 +12,7 @@ const props = defineProps({
 
 const navItems = computed(() => {
   const items = []
-  config.website.menu_items.forEach((item) => {
+  config.website.router_items.forEach((item) => {
     if (item.display_menu) {
       items.push({
         to: item.linkPage,

--- a/src/services/routerUtils.js
+++ b/src/services/routerUtils.js
@@ -15,7 +15,7 @@ import OrganizationsListView from '../views/organizations/OrganizationsListView.
 export default class RouterFetch {
   generateRouteItems() {
     const items = []
-    config.website.menu_items.forEach((item) => {
+    config.website.router_items.forEach((item) => {
       if (item.id === 'datasets') {
         items.push({
           path: item.linkPage,

--- a/src/views/bouquets/BouquetEditView.vue
+++ b/src/views/bouquets/BouquetEditView.vue
@@ -109,7 +109,7 @@ const availabilityEnum = {
 }
 
 const goToDatasetPage = (id) => {
-  const url = config.website.menu_items.find(
+  const url = config.website.router_items.find(
     (link) => link.linkPage === '/datasets'
   )
   return `${url.linkPage}/${id}`


### PR DESCRIPTION
Nom de variable plus parlant pour `router_items`, cf https://github.com/ecolabdata/ecospheres-front/pull/259#discussion_r1424117260